### PR TITLE
get rids of warning: FutureWarning: xarray.DataArray.__contains__ ...

### DIFF
--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -269,7 +269,7 @@ def dft(da, spacing_tol=1e-3, dim=None, shift=True, detrend=None, window=False):
     for d in newdims:
         if d in k_coords:
             newcoords[d] = k_coords[d]
-        elif d in da:
+        elif d in da.coords:
             newcoords[d] = da[d].data
 
     dk = [l[1] - l[0] for l in k]


### PR DESCRIPTION
```
FutureWarning: xarray.DataArray.__contains__ crrently checks membership in DataArray.coords, but in xarray v0.11 will change to check membership in array values.   
elif d in da:
```
Not sure this is the proper way to do this, but it got rid of the warning for me.
