### PR TITLE
Fixed test_dft_1d so it passes

### DIFF
--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -103,7 +103,7 @@ def test_dft_1d(test_data_1d):
     """Test the discrete Fourier transform function on one-dimensional data."""
     da = test_data_1d
     Nx = len(da)
-    dx = float(da.x[1] - da.x[0]) if 'x' in da else 1
+    dx = float(da.x[1] - da.x[0]) if 'x' in da.dims else 1
 
     # defaults with no keyword args
     ft = xrft.dft(da, detrend='constant')


### PR DESCRIPTION
Found the problem causing #52, and fixed it so tests now pass. 

It was an issue with the tests not the code. It was because iterating over a dataarray iterates over the values in the array, rather than over the names of the dimensions as the test assumed. 

How did the failing tests get merged? Did this behaviour change in xarray at some point? I'm using the development master version of xarray. Does xrft need to specify minimum versions of its dependencies?