### PR TITLE
Option to use real fft

### DIFF
--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -204,7 +204,7 @@ def test_dft_real(test_data_1d):
     # check that the frequency dimension was created properly
     assert ft.dims == ('freq_x',)
     # check that the coords are correct
-    freq_x_expected = np.fft.fftshift(np.fft.rfftfreq(Nx, dx))
+    freq_x_expected = np.fft.rfftfreq(Nx, dx)
     npt.assert_allclose(ft['freq_x'], freq_x_expected)
     # check that a spacing variable was created
     assert ft['freq_x_spacing'] == freq_x_expected[1] - freq_x_expected[0]
@@ -212,7 +212,7 @@ def test_dft_real(test_data_1d):
     assert isinstance(ft.data, type(da.data))
     # check that the Fourier transform itself is correct
     data = (da - da.mean()).values
-    ft_data_expected = np.fft.fftshift(np.fft.rfft(data))
+    ft_data_expected = np.fft.rfft(data)
     # because the zero frequency component is zero, there is a numerical
     # precision issue. Fixed by setting atol
     npt.assert_allclose(ft_data_expected, ft.values, atol=1e-14)

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -103,7 +103,7 @@ def test_dft_1d(test_data_1d):
     """Test the discrete Fourier transform function on one-dimensional data."""
     da = test_data_1d
     Nx = len(da)
-    dx = float(da.x[1] - da.x[0]) if 'x' in da else 1
+    dx = float(da.x[1] - da.x[0]) if 'x' in da.dims else 1
 
     # defaults with no keyword args
     ft = xrft.dft(da, detrend='constant')

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -209,7 +209,8 @@ def dft(da, spacing_tol=1e-3, dim=None, real=False, shift=True, detrend=None,
         Whether the input array is all real or not. If set to True will return
         only positive frequencies. Defaults to False.
     shift : bool, default
-        Whether to shift the fft output.
+        Whether to shift the fft output. Default is True, unless `real=True`,
+        in which case shift will be set to False always.
     detrend : str, optional
         If `constant`, the mean across the transform dimensions will be
         subtracted before calculating the Fourier transform (FT).
@@ -247,7 +248,9 @@ def dft(da, spacing_tol=1e-3, dim=None, real=False, shift=True, detrend=None,
                                     "must have the chunk length of 1.")
 
     fft = _fft_module(da)
+
     if real:
+        shift = False
         fftfreq = np.fft.rfftfreq
         fft_fn = fft.rfftn
     else:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -206,8 +206,8 @@ def dft(da, spacing_tol=1e-3, dim=None, real=False, shift=True, detrend=None,
         The dimensions along which to take the transformation. If `None`, all
         dimensions will be transformed.
     real : bool, optional
-        Whether the input array is all real or not. If set to True will return
-        only positive frequencies. Defaults to False.
+        Whether the input array is all real or not. If set to True the
+        redundant negative frequencies will be discarded. Defaults to False.
     shift : bool, default
         Whether to shift the fft output. Default is True, unless `real=True`,
         in which case shift will be set to False always.
@@ -251,10 +251,8 @@ def dft(da, spacing_tol=1e-3, dim=None, real=False, shift=True, detrend=None,
 
     if real:
         shift = False
-        fftfreq = np.fft.rfftfreq
         fft_fn = fft.rfftn
     else:
-        fftfreq = np.fft.fftfreq
         fft_fn = fft.fftn
 
     if chunks_to_segments:
@@ -279,10 +277,18 @@ def dft(da, spacing_tol=1e-3, dim=None, real=False, shift=True, detrend=None,
             raise ValueError("Can't take Fourier transform because "
                              "coodinate %s is not evenly spaced" % d)
         delta_x.append(delta)
+
     # calculate frequencies from coordinates
     # coordinates are always loaded eagerly, so we use numpy
+    if real:
+        # Discard negative frequencies from transform along last axis to be
+        # consistent with np.fft.rfftn
+        fftfreq = [np.fft.fftfreq]*(len(N)-1)
+        fftfreq.append(np.fft.rfftfreq)
+    else:
+        fftfreq = [np.fft.fftfreq]*len(N)
 
-    k = [fftfreq(Nx, dx) for (Nx, dx) in zip(N, delta_x)]
+    k = [fftfreq(Nx, dx) for (fftfreq, Nx, dx) in zip(fftfreq, N, delta_x)]
 
     if detrend == 'constant':
         da = da - da.mean(dim=dim)


### PR DESCRIPTION
Added an option to do a real fft instead of assuming that you always wish to retain negative frequencies.

Required wrapping `np.fft.rfftn` instead of `np.fft.fftn`, and setting `shift=False` if `real=True`.

- [x] Tests (for 1d data)
- [x] Docstring