### PR TITLE
implementing real=coords

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+description-file = README.md
+
 [aliases]
 test=pytest
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -243,6 +243,8 @@ class TestDFTReal(object):
         daft = xrft.dft(da, real='x')
         npt.assert_almost_equal(daft.values,
                                np.fft.rfftn(da.transpose('y','x')).transpose())
+        npt.assert_almost_equal(daft.values,
+                               xrft.dft(da, dim=['y'], real='x'))
 
         actual_freq_x = daft.coords['freq_x'].values
         expected_freq_x = np.fft.rfftfreq(Nx, dx)

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -208,7 +208,7 @@ class TestDFTReal(object):
         dx = float(da.x[1] - da.x[0]) if 'x' in da.dims else 1
 
         # defaults with no keyword args
-        ft = xrft.dft(da, real=['x'], detrend='constant')
+        ft = xrft.dft(da, real='x', detrend='constant')
         # check that the frequency dimension was created properly
         assert ft.dims == ('freq_x',)
         # check that the coords are correct
@@ -237,7 +237,7 @@ class TestDFTReal(object):
         dx = float(da.x[1] - da.x[0])
         dy = float(da.y[1] - da.y[0])
 
-        daft = xrft.dft(da, real=['y','x'])
+        daft = xrft.dft(da, real='x')
         npt.assert_almost_equal(daft.values,
                                np.fft.rfftn(da.transpose('y','x')).transpose())
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -225,6 +225,9 @@ class TestDFTReal(object):
         # precision issue. Fixed by setting atol
         npt.assert_allclose(ft_data_expected, ft.values, atol=1e-14)
 
+        with pytest.raises(ValueError):
+            xrft.dft(da, real='y', detrend='constant')
+
     def test_dft_real_2d(self):
         """
         Test the real discrete Fourier transform function on one-dimensional

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -347,15 +347,18 @@ def test_power_spectrum():
     """Test the power spectrum function"""
     N = 16
     da = xr.DataArray(np.random.rand(N,N), dims=['x','y'],
-                    coords={'x':range(N),'y':range(N)}
+                     coords={'x':range(N),'y':range(N)}
                      )
     ps = xrft.power_spectrum(da, window=True, density=False,
                             detrend='constant')
-    daft = xrft.dft(da,
-                    dim=None, shift=True, detrend='constant',
-                    window=True)
+    daft = xrft.dft(da, detrend='constant', window=True)
     npt.assert_almost_equal(ps.values, np.real(daft*np.conj(daft)))
     npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.)
+
+    ps = xrft.power_spectrum(da, real='x', window=True, density=False,
+                            detrend='constant')
+    daft = xrft.dft(da, real='x', detrend='constant', window=True)
+    npt.assert_almost_equal(ps.values, np.real(daft*np.conj(daft)))
 
     ### Normalized
     dim = da.dims

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -208,7 +208,7 @@ class TestDFTReal(object):
         dx = float(da.x[1] - da.x[0]) if 'x' in da.dims else 1
 
         # defaults with no keyword args
-        ft = xrft.dft(da, real=True, detrend='constant')
+        ft = xrft.dft(da, real=['x'], detrend='constant')
         # check that the frequency dimension was created properly
         assert ft.dims == ('freq_x',)
         # check that the coords are correct
@@ -237,15 +237,16 @@ class TestDFTReal(object):
         dx = float(da.x[1] - da.x[0])
         dy = float(da.y[1] - da.y[0])
 
-        daft = xrft.dft(da, real=True)
-        npt.assert_almost_equal(daft.values, np.fft.rfftn(da.values))
+        daft = xrft.dft(da, real=['y','x'])
+        npt.assert_almost_equal(daft.values,
+                               np.fft.rfftn(da.transpose('y','x')).transpose())
 
         actual_freq_x = daft.coords['freq_x'].values
-        expected_freq_x = np.fft.fftfreq(Nx, dx)
+        expected_freq_x = np.fft.rfftfreq(Nx, dx)
         npt.assert_almost_equal(actual_freq_x, expected_freq_x)
 
         actual_freq_y = daft.coords['freq_y'].values
-        expected_freq_y = np.fft.rfftfreq(Ny, dy)
+        expected_freq_y = np.fft.fftfreq(Ny, dy)
         npt.assert_almost_equal(actual_freq_y, expected_freq_y)
 
 
@@ -478,13 +479,13 @@ class TestCrossPhase(object):
         if dask:
             da1 = da1.chunk({'x': 32})
             da2 = da2.chunk({'x': 32})
-        cp = xrft.cross_phase(da1, da2, dim='x')
+        cp = xrft.cross_phase(da1, da2, dim=['x'], real=['x'])
 
         actual_phase_offset = cp.sel(freq_x=f).values
         npt.assert_almost_equal(actual_phase_offset, phase_offset)
         assert cp.name == 'a_b_phase'
 
-        xrt.assert_equal(xrft.cross_phase(da1, da2, dim=None), cp)
+        xrt.assert_equal(xrft.cross_phase(da1, da2, real=['x']), cp)
 
         with pytest.raises(ValueError):
             xrft.cross_phase(da1, da2.isel(x=0).drop('x'))

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -209,10 +209,8 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     dim : list, optional
         The dimensions along which to take the transformation. If `None`, all
         dimensions will be transformed.
-    real : list, optional
-        Default is `None` where no real Fourier transform (FT) will be taken.
-        Otherwise, reorder the dimensions to this order and uses the real FT
-        along the last dimesion.
+    real : str, optional
+        Real Fourier transform will be taken along this dimension.
     shift : bool, default
         Whether to shift the fft output. Default is `True`, unless `real=True`,
         in which case shift will be set to False always.
@@ -238,8 +236,15 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         raise TypeError("Please provide a float argument")
 
     rawdims = da.dims
-    if real is not None and len(real)>0:
-        da = da.transpose(*real)
+    if real is not None:
+        transdim = list(rawdims)
+        if real not in transdim:
+            raise ValueError("The dimension along real FT is taken must "
+                            "be one of the existing dimensions.")
+        elif real != transdim[-1]:
+            transdim.remove(real)
+            transdim += [real]
+            da = da.transpose(*transdim)
     if dim is None:
         dim = da.dims
 
@@ -538,10 +543,10 @@ def cross_phase(da1, da2, spacing_tol=1e-3, dim=None, detrend=None,
                         'a single dimension.')
 
     daft1 = dft(da1, spacing_tol,
-                dim=dim, real=dim, shift=False, detrend=detrend,
+                dim=dim, real=dim[0], shift=False, detrend=detrend,
                 window=window, chunks_to_segments=chunks_to_segments)
     daft2 = dft(da2, spacing_tol,
-                dim=dim, real=dim, shift=False, detrend=detrend,
+                dim=dim, real=dim[0], shift=False, detrend=detrend,
                 window=window, chunks_to_segments=chunks_to_segments)
 
     if daft1.chunks and daft2.chunks:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -210,9 +210,9 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         The dimensions along which to take the transformation. If `None`, all
         dimensions will be transformed.
     real : list, optional
-        Default is `None` where no transposing will be applied. Otherwise,
-        reorder the dimensions to this order and the real Fourier transform
-        will be taken upon the last dimesion.
+        Default is `None` where no real Fourier transform (FT) will be taken.
+        Otherwise, reorder the dimensions to this order and uses the real FT
+        along the last dimesion.
     shift : bool, default
         Whether to shift the fft output. Default is `True`, unless `real=True`,
         in which case shift will be set to False always.
@@ -489,7 +489,7 @@ def cross_spectrum(da1, da2, spacing_tol=1e-3, dim=None,
     return cs
 
 
-def cross_phase(da1, da2, spacing_tol=1e-3, dim=None, real=None, detrend=None,
+def cross_phase(da1, da2, spacing_tol=1e-3, dim=None, detrend=None,
                 window=False, chunks_to_segments=False):
     """
     Calculates the cross-phase between da1 and da2.
@@ -511,12 +511,8 @@ def cross_phase(da1, da2, spacing_tol=1e-3, dim=None, real=None, detrend=None,
         Spacing tolerance. Fourier transform should not be applied to uneven grid but
         this restriction can be relaxed with this setting. Use caution.
     dim : list, optional
-        The dimensions along which to take the transformation. If `None`, all
-        dimensions will be transformed.
-    real : list, optional
-        Default is `None` where no transposing will be applied. Otherwise,
-        reorder the dimensions to this order and the real Fourier transform
-        will be taken upon the last dimesion.
+        The dimension along which to take the real Fourier transformation.
+        If `None`, all dimensions will be transformed.
     shift : bool, optional
         Whether to shift the fft output.
     detrend : str, optional
@@ -542,12 +538,15 @@ def cross_phase(da1, da2, spacing_tol=1e-3, dim=None, real=None, detrend=None,
             raise ValueError('The two datasets have different dimensions')
     elif not isinstance(dim, list):
         dim = [dim]
+    if len(dim)>1:
+        raise ValueError('Cross phase calculation should only be done along '
+                        'a single dimension.')
 
     daft1 = dft(da1, spacing_tol,
-                dim=dim, real=real, shift=False, detrend=detrend,
+                dim=dim, real=dim, shift=False, detrend=detrend,
                 window=window, chunks_to_segments=chunks_to_segments)
     daft2 = dft(da2, spacing_tol,
-                dim=dim, real=real, shift=False, detrend=detrend,
+                dim=dim, real=dim, shift=False, detrend=detrend,
                 window=window, chunks_to_segments=chunks_to_segments)
 
     if daft1.chunks and daft2.chunks:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -339,12 +339,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     if real is None:
         return daft
     else:
-        enddims = list(rawdims)
-        i = 0
-        for d in rawdims:
-            if d in dim:
-                enddims[i] = prefix + d
-            i += 1
+        enddims = [prefix + d for d in rawdims if d in dim]
         return daft.transpose(*enddims)
 
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -236,6 +236,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         raise TypeError("Please provide a float argument")
 
     rawdims = da.dims
+    trans = False
     if real is not None:
         transdim = list(rawdims)
         if real not in transdim:
@@ -245,6 +246,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
             transdim.remove(real)
             transdim += [real]
             da = da.transpose(*transdim)
+            trans = True
     if dim is None:
         dim = da.dims
 
@@ -341,11 +343,11 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         newcoords[prefix + d + '_spacing'] = this_dk
 
     daft = xr.DataArray(f, dims=newdims, coords=newcoords)
-    if real is None:
-        return daft
-    else:
+    if trans:
         enddims = [prefix + d for d in rawdims if d in dim]
         return daft.transpose(*enddims)
+    else:
+        return daft
 
 
 def power_spectrum(da, spacing_tol=1e-3, dim=None, shift=True, detrend=None, density=True,

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -248,7 +248,9 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
             da = da.transpose(*transdim)
             trans = True
     if dim is None:
-        dim = da.dims
+        dim = list(da.dims)
+    if real is not None and real not in dim:
+        dim += [real]
 
     if not da.chunks:
         if np.isnan(da.values).any():


### PR DESCRIPTION
I implemented #57 and the tests are passing. I made the `real` argument so that the user gives a list of the order how they would want the input transposed and returns the real FFT with the same order of dimensions as the original input, e.g. the argument of `dim=['time'], real=['Y','X','time']` to take the real FFT over `time` for a dataset with dimensions of `['time','Y','X']` would return `['freq_time','Y','X']`.

I don't use real FFTs that much so would be great if @TomNicholas and @dcherian could try it out and see how it suits their needs :)