### PR TITLE
isospectrum debugging / refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ notifications:
 #     repo: rabernat/xrft
 
 python:
-  - 2.7
   - 3.6
 
 env:

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -736,8 +736,13 @@ def test_isotropic_ps():
     da = da[:,0,:,:,:].drop(['zz'])
     with pytest.raises(ValueError):
         xrft.isotropic_power_spectrum(da, dim=['z','y','x'])
-    iso_ps = xrft.isotropic_power_spectrum(da, dim=['y','x']).values
-    npt.assert_almost_equal(np.ma.masked_invalid(iso_ps[:,:,1:]).mask.sum(), 0.)
+    iso_ps = xrft.isotropic_power_spectrum(da, dim=['y','x'])
+    npt.assert_almost_equal(
+            np.ma.masked_invalid(iso_ps.values[:,:,1:]).mask.sum(),
+            0.)
+    # test soon deprecated function
+    iso_ps_dep = xrft.isotropic_powerspectrum(da, dim=['y','x'])
+    assert iso_ps_dep.identical(iso_ps)
 
 def test_isotropic_cs():
     """Test isotropic cross spectrum"""
@@ -774,8 +779,14 @@ def test_isotropic_cs():
         xrft.isotropic_cross_spectrum(da, da2, dim=['z','y','x'])
 
     iso_cs = xrft.isotropic_cross_spectrum(da, da2, dim=['y','x'],
-                                         window=True).values
-    npt.assert_almost_equal(np.ma.masked_invalid(iso_cs[:,:,1:]).mask.sum(), 0.)
+                                         window=True)
+    npt.assert_almost_equal(
+            np.ma.masked_invalid(iso_cs.values[:,:,1:]).mask.sum(), 
+            0.)
+    # test soon deprecated function
+    iso_cs_dep = xrft.isotropic_crossspectrum(da, da2, dim=['y','x'],
+                                            window=True)
+    assert iso_cs_dep.identical(iso_cs)
 
 def test_spacing_tol(test_data_1d):
     da = test_data_1d

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -729,8 +729,6 @@ def test_isotropic_ps():
                                           dtype='datetime64'),
                          'zz': np.arange(5), 'z': np.arange(5),
                          'y': np.arange(16), 'x': np.arange(32)})
-    with pytest.raises(ValueError):
-        xrft.isotropic_power_spectrum(da, dim=['y','x'])
     da = da[:,0,:,:,:].drop(['zz'])
     with pytest.raises(ValueError):
         xrft.isotropic_power_spectrum(da, dim=['z','y','x'])
@@ -766,8 +764,6 @@ def test_isotropic_cs():
                                           dtype='datetime64'),
                          'zz': np.arange(5), 'z': np.arange(5),
                          'y': np.arange(16), 'x': np.arange(32)})
-    with pytest.raises(ValueError):
-        xrft.isotropic_cross_spectrum(da, da2, dim=['y','x'])
     da = da[:,0,:,:,:].drop(['zz'])
     da2 = da2[:,0,:,:,:].drop(['zz'])
     with pytest.raises(ValueError):

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -652,6 +652,13 @@ def _synthetic_field(N, dL, amp, s):
     theta = np.fft.ifft2(np.fft.ifftshift(F_theta))
     return np.real(theta)
 
+def test_isotropize(N=512, dL=1., amp=1e1, s=-3.):
+    """Test the isotropization of a power spectrum."""
+    # generate synthetic 2D spectrum, isotropize and check values
+    # check options in isotropize
+    #ps_iso = xrft.isotropize(ps, fftdim, nfactor=4)
+    
+
 def test_isotropic_ps_slope(N=512, dL=1., amp=1e1, s=-3.):
     """Test the spectral slope of isotropic power spectrum."""
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -740,9 +740,6 @@ def test_isotropic_ps():
     npt.assert_almost_equal(
             np.ma.masked_invalid(iso_ps.values[:,:,1:]).mask.sum(),
             0.)
-    # test soon deprecated function
-    iso_ps_dep = xrft.isotropic_powerspectrum(da, dim=['y','x'])
-    assert iso_ps_dep.identical(iso_ps)
 
 def test_isotropic_cs():
     """Test isotropic cross spectrum"""
@@ -783,10 +780,6 @@ def test_isotropic_cs():
     npt.assert_almost_equal(
             np.ma.masked_invalid(iso_cs.values[:,:,1:]).mask.sum(), 
             0.)
-    # test soon deprecated function
-    iso_cs_dep = xrft.isotropic_crossspectrum(da, da2, dim=['y','x'],
-                                            window=True)
-    assert iso_cs_dep.identical(iso_cs)
 
 def test_spacing_tol(test_data_1d):
     da = test_data_1d

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -652,11 +652,13 @@ def _synthetic_field(N, dL, amp, s):
     theta = np.fft.ifft2(np.fft.ifftshift(F_theta))
     return np.real(theta)
 
-def test_isotropize(N=512, dL=1., amp=1e1, s=-3.):
+def test_isotropize(Nx=512, Ny=256, chunkx=128, chunky=128):
     """Test the isotropization of a power spectrum."""
     # generate synthetic 2D spectrum, isotropize and check values
     # check options in isotropize
     #ps_iso = xrft.isotropize(ps, fftdim, nfactor=4)
+    # test with and without chunks
+    pass
     
 
 def test_isotropic_ps_slope(N=512, dL=1., amp=1e1, s=-3.):

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -648,8 +648,10 @@ def isotropize(ps, fftdim, nfactor=4):
 
     # average azimuthally
     ps = ps.assign_coords(freq_r=np.sqrt(k**2+l**2))
-    iso_ps = ps.groupby_bins('freq_r', bins=ki, labels=kr).mean()        
-    return iso_ps.rename({'freq_r_bins': 'freq_r'})
+    iso_ps = (ps.groupby_bins('freq_r', bins=ki, labels=kr).mean()
+              .rename({'freq_r_bins': 'freq_r'})
+             )
+    return iso_ps * iso_ps.freq_r
 
 def isotropic_powerspectrum(*args, **kwargs):
     """ 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -687,7 +687,7 @@ def isotropize(ps, fftdim, nfactor=4):
     for d in newdims:
         if d in ps.coords:
             newcoords[d] = ps.coords[d].values
-        else:
+        elif d in k_coords:
             newcoords[d] = k_coords[d]
             
     return xr.DataArray(iso_ps, dims=newdims, coords=newcoords)
@@ -750,7 +750,7 @@ def isotropic_powerspectrum(da, spacing_tol=1e-3, dim=None, shift=True,
     # adhoc reordering that seem to works    
     fftdim = [d for d in ps.dims if d in fftdim]
 
-    return ps, isotropize(ps, fftdim, nfactor=nfactor)
+    return isotropize(ps, fftdim, nfactor=nfactor)
 
 def isotropic_crossspectrum(da1, da2, spacing_tol=1e-3,
                            dim=None, shift=True, detrend=None,

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -814,7 +814,7 @@ def isotropic_crossspectrum(da1, da2, spacing_tol=1e-3,
     fftdim = ['freq_' + d for d in dim]
     # line below results from weakness in isotropize, should disapear
     # adhoc reordering that seem to works
-    fftdim = [d for d in ps.dims if d in fftdim]
+    fftdim = [d for d in cs.dims if d in fftdim]
 
     return isotropize(cs, fftdim, nfactor=nfactor)
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -765,9 +765,6 @@ def isotropic_power_spectrum(da, spacing_tol=1e-3, dim=None, shift=True,
                        window=window)
 
     fftdim = ['freq_' + d for d in dim]
-    # line below results from weakness in isotropize, should disapear
-    # adhoc reordering that seem to works    
-    #fftdim = [d for d in ps.dims if d in fftdim]
 
     return isotropize(ps, fftdim, nfactor=nfactor)
 
@@ -842,9 +839,6 @@ def isotropic_cross_spectrum(da1, da2, spacing_tol=1e-3,
                        window=window)
 
     fftdim = ['freq_' + d for d in dim]
-    # line below results from weakness in isotropize, should disapear
-    # adhoc reordering that seem to works
-    #fftdim = [d for d in cs.dims if d in fftdim]
 
     return isotropize(cs, fftdim, nfactor=nfactor)
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -614,7 +614,7 @@ def _radial_wvnum(k, l, N, nfactor):
     area = np.bincount(kidx)
     # compute the average radial wavenumber for each bin
     kr = np.bincount(kidx, weights=K.ravel()) \
-            / np.ma.masked_where(area>0, area)
+            / np.ma.masked_where(area==0, area)
 
     return kidx, area, kr
 
@@ -635,7 +635,7 @@ def _azimuthal_avg(kidx, f, area, kr):
         _bincount = _bincount.compute()
 
     #iso_f = np.ma.masked_invalid(_bincount / area) * kr
-    iso_f = _bincount / np.ma.masked_where(area>0, area) * kr
+    iso_f = _bincount / np.ma.masked_where(area==0, area) * kr
 
     return iso_f
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -643,9 +643,8 @@ def _azi_wrapper(M, kidx, f, area, kr):
 
 def isotropize(ps, fftdim, nfactor=4):
     """
-    Calculates the isotropic spectrum from the
-    two-dimensional power spectrum by taking the
-    azimuthal average.
+    Isotropize a 2D power spectrum or cross spectrum 
+    by taking an azimuthal average.
 
     .. math::
         \text{iso}_{ps} = k_r N^{-1} \sum_{N} |\mathbb{F}(da')|^2
@@ -655,7 +654,7 @@ def isotropize(ps, fftdim, nfactor=4):
     Parameters
     ----------
     ps : `xarray.DataArray`
-        The power spectrum to be isotropized.
+        The power spectrum or cross spectrum to be isotropized.
     fftdim : list
         The fft dimensions overwhich the isotropization must be performed.
     nfactor : int, optional
@@ -691,8 +690,17 @@ def isotropize(ps, fftdim, nfactor=4):
             newcoords[d] = k_coords[d]
             
     return xr.DataArray(iso_ps, dims=newdims, coords=newcoords)
+
+def isotropic_powerspectrum(*args, **kwargs):
+    """ 
+    Deprecated function. See isotropic_power_spectrum doc
+    """
+    import warnings
+    msg = "Deprecated. Use isotropic_power_spectrum instead"
+    raise warnings.DeprecationWarning(msg)
+    return isotropic_power_spectrum(*args, **kwargs)
     
-def isotropic_powerspectrum(da, spacing_tol=1e-3, dim=None, shift=True,
+def isotropic_power_spectrum(da, spacing_tol=1e-3, dim=None, shift=True,
                            detrend=None, density=True, window=False, nfactor=4):
     """
     Calculates the isotropic spectrum from the
@@ -703,6 +711,8 @@ def isotropic_powerspectrum(da, spacing_tol=1e-3, dim=None, shift=True,
         \text{iso}_{ps} = k_r N^{-1} \sum_{N} |\mathbb{F}(da')|^2
 
     where :math:`N` is the number of azimuthal bins.
+
+    Note: the method is not lazy does trigger computations.
 
     Parameters
     ----------
@@ -752,7 +762,16 @@ def isotropic_powerspectrum(da, spacing_tol=1e-3, dim=None, shift=True,
 
     return isotropize(ps, fftdim, nfactor=nfactor)
 
-def isotropic_crossspectrum(da1, da2, spacing_tol=1e-3,
+def isotropic_crossspectrum(*args, **kwargs):
+    """ 
+    Deprecated function. See isotropic_cross_spectrum doc
+    """
+    import warnings
+    msg = "Deprecated. Use isotropic_cross_spectrum instead"
+    raise warnings.DeprecationWarning(msg)
+    return isotropic_cross_spectrum(*args, **kwargs)
+
+def isotropic_cross_spectrum(da1, da2, spacing_tol=1e-3,
                            dim=None, shift=True, detrend=None,
                            density=True, window=False, nfactor=4):
     """
@@ -764,6 +783,8 @@ def isotropic_crossspectrum(da1, da2, spacing_tol=1e-3,
         \text{iso}_{cs} = k_r N^{-1} \sum_{N} (\mathbb{F}(da1') {\mathbb{F}(da2')}^*)
 
     where :math:`N` is the number of azimuthal bins.
+    
+    Note: the method is not lazy does trigger computations.
 
     Parameters
     ----------

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -613,7 +613,8 @@ def _radial_wvnum(k, l, N, nfactor):
     # compute number of points for each wavenumber
     area = np.bincount(kidx)
     # compute the average radial wavenumber for each bin
-    kr = np.bincount(kidx, weights=K.ravel()) / area
+    kr = np.bincount(kidx, weights=K.ravel()) \
+            / np.ma.masked_where(area>0, area)
 
     return kidx, area, kr
 
@@ -632,8 +633,9 @@ def _azimuthal_avg(kidx, f, area, kr):
     if type(_bincount)==dsar.core.Array:
         # required for python 2.7 
         _bincount = _bincount.compute()
-        
-    iso_f = np.ma.masked_invalid(_bincount / area) * kr
+
+    #iso_f = np.ma.masked_invalid(_bincount / area) * kr
+    iso_f = _bincount / np.ma.masked_where(area>0, area) * kr
 
     return iso_f
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -623,12 +623,16 @@ def _azimuthal_avg(kidx, f, area, kr):
     """
     
     if type(f)==dsar.core.Array:
-        _bincount = np.bincount(dsar.from_array(kidx), weights=f).compute()
+        _bincount = np.bincount(dsar.from_array(kidx), weights=f)        
         # the shape of _bincount is (nan,) if we don't compute
         # which breaks the divisions below with for example:
         # ValueError: operands could not be broadcast together with shapes (nan,) (65,)
     else:
         _bincount = np.bincount(kidx, weights=f)
+    if type(_bincount)==dsar.core.Array:
+        # required for python 2.7 
+        _bincount = _bincount.compute()
+        
     iso_f = np.ma.masked_invalid(_bincount / area) * kr
 
     return iso_f

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -658,7 +658,8 @@ def isotropic_powerspectrum(*args, **kwargs):
     Deprecated function. See isotropic_power_spectrum doc
     """
     import warnings
-    msg = "Deprecated. Use isotropic_power_spectrum instead"
+    msg = "This function has been renamed and will disappear in the future."\
+          +" Please use isotropic_power_spectrum instead"
     warnings.warn(msg, Warning)
     return isotropic_power_spectrum(*args, **kwargs)
     
@@ -726,7 +727,8 @@ def isotropic_crossspectrum(*args, **kwargs):
     Deprecated function. See isotropic_cross_spectrum doc
     """
     import warnings
-    msg = "Deprecated. Use isotropic_cross_spectrum instead"
+    msg = "This function has been renamed and will disappear in the future."\
+          +" Please use isotropic_cross_spectrum instead"
     warnings.warn(msg, Warning)
     return isotropic_cross_spectrum(*args, **kwargs)
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -653,7 +653,7 @@ def isotropize(ps, fftdim, nfactor=4):
              )
     return iso_ps * iso_ps.freq_r
 
-def isotropic_powerspectrum(*args, **kwargs):
+def isotropic_powerspectrum(*args, **kwargs): # pragma: no cover
     """ 
     Deprecated function. See isotropic_power_spectrum doc
     """
@@ -722,7 +722,7 @@ def isotropic_power_spectrum(da, spacing_tol=1e-3, dim=None, shift=True,
 
     return isotropize(ps, fftdim, nfactor=nfactor)
 
-def isotropic_crossspectrum(*args, **kwargs):
+def isotropic_crossspectrum(*args, **kwargs): # pragma: no cover
     """ 
     Deprecated function. See isotropic_cross_spectrum doc
     """


### PR DESCRIPTION
This PR attemps to fix several issues related to isospectrum computations:

- breaks with dask arrays (dask bincount does not handle mixed types arguments)

- breaks with extra dimensions

See [gist](https://gist.github.com/apatlpo/54f61a697d426cd5522ed1d18db66f13) for illustration of failures

I also propose a modest refactoring which consists in adding an isotropize methods that average spectra or crossspectra azimuthaly.
This method is called by isotropic_powerspectrum and isotropic_crossspectrum

There are still some improvements that could be made:

-  isotropize could be made more robust
-  the present form is not lazy (because dask bincount is not able to predict array size)

If you believe this PR is worth anything, let me know, I can finetune, even though weeks to come are going to be busy with Ocean Sciences and all.

cheers

