### PR TITLE
Fix dependencies listed under install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'future', 'docrep']
+INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'pandas', 'scipy']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 2.8', 'coverage']
 


### PR DESCRIPTION
I'm excited to give xrft a try!

I noticed that future and docrep are no longer imported in xrft.py, but pandas
and scipy are, so this PR updates dependencies accordingly in setup.py.