### PR TITLE
cftime convention for noleap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ python:
   - 3.8
 
 env:
-  - CONDA_DEPS="pip flake8 pytest coverage numpy scipy pandas xarray dask" PIP_DEPS="codecov pytest-cov"
+  - CONDA_DEPS="pip flake8 pytest coverage numpy scipy pandas xarray dask cftime" PIP_DEPS="codecov pytest-cov"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'pandas', 'scipy']
+INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'pandas', 'scipy','cftime']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 2.8', 'coverage']
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'pandas', 'scipy','cftime']
+INSTALL_REQUIRES = ['xarray', 'dask', 'numpy', 'pandas', 'scipy']
+EXTRAS_REQUIRE = ['cftime']
 SETUP_REQUIRES = ['pytest-runner']
 TESTS_REQUIRE = ['pytest >= 2.8', 'coverage']
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -198,6 +198,15 @@ class TestDFTImag(object):
         freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)
 
+        time = cftime.num2date(np.arange(0,10*365), units, '360_day')
+        Nt = len(time)
+        da = xr.DataArray(np.arange(len(time)), dims='time',
+                                    coords=[time])
+        ft = xrft.dft(da, shift=False)
+        dt = np.diff(time)[0].total_seconds()
+        freq_time_expected = np.fft.fftfreq(Nt, dt)
+        npt.assert_allclose(ft['freq_time'], freq_time_expected)
+
     def test_dft_2d(self):
         """Test the discrete Fourier transform on 2D data"""
         N = 16

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
+import cftime
 import dask.array as dsar
 
 import scipy.signal as sps
@@ -166,6 +167,19 @@ class TestDFTImag(object):
         # check that frequencies are correct
         dt = (time[1] - time[0]).total_seconds()
         freq_time_expected = np.fft.fftshift(np.fft.fftfreq(Nt, dt))
+        npt.assert_allclose(ft['freq_time'], freq_time_expected)
+
+        # test cftime
+        units = 'days since 2000-01-01 00:00:00'
+        time = cftime.num2date(np.arange(0,10*365), units, '365_day', 'noleap')
+        Nt = len(time)
+        da = xr.DataArray(np.arange(len(time)), dims='time',
+                                    coords=[time])
+
+        ft = xrft.dft(da, shift=False)
+        # num = cftime.date2num(time,'hours since 1800-01-01 00:00:00','noleap')
+        dt = np.diff(time)[0].total_seconds()
+        freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)
 
     def test_dft_2d(self):

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -41,7 +41,7 @@ def test_data_1d(request):
     return da
 
 @pytest.fixture(params=['pandas','standard','julian','365_day','360_day'])
-def test_time(request):
+def time_data(request):
     if request.param == 'pandas':
         return pd.date_range('2000-01-01', '2001-01-01', closed='left')
     else:
@@ -165,9 +165,9 @@ class TestDFTImag(object):
                 ft = xrft.dft(da)
 
 
-    def test_dft_1d_time(self,test_time):
+    def test_dft_1d_time(self,time_data):
         """Test the discrete Fourier transform function on timeseries data."""
-        time = test_time
+        time = time_data
         Nt = len(time)
         da = xr.DataArray(np.random.rand(Nt), coords=[time], dims=['time'])
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -177,7 +177,18 @@ class TestDFTImag(object):
                                     coords=[time])
 
         ft = xrft.dft(da, shift=False)
-        
+
+        dt = np.diff(time)[0].total_seconds()
+        freq_time_expected = np.fft.fftfreq(Nt, dt)
+        npt.assert_allclose(ft['freq_time'], freq_time_expected)
+
+        time = cftime.num2date(np.arange(0,10*365), units)
+        Nt = len(time)
+        da = xr.DataArray(np.arange(len(time)), dims='time',
+                                    coords=[time])
+
+        ft = xrft.dft(da, shift=False)
+
         dt = np.diff(time)[0].total_seconds()
         freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -175,9 +175,7 @@ class TestDFTImag(object):
         Nt = len(time)
         da = xr.DataArray(np.arange(len(time)), dims='time',
                                     coords=[time])
-
         ft = xrft.dft(da, shift=False)
-
         dt = np.diff(time)[0].total_seconds()
         freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)
@@ -186,9 +184,16 @@ class TestDFTImag(object):
         Nt = len(time)
         da = xr.DataArray(np.arange(len(time)), dims='time',
                                     coords=[time])
-
         ft = xrft.dft(da, shift=False)
+        dt = np.diff(time)[0].total_seconds()
+        freq_time_expected = np.fft.fftfreq(Nt, dt)
+        npt.assert_allclose(ft['freq_time'], freq_time_expected)
 
+        time = cftime.num2date(np.arange(0,10*365), units, 'julian')
+        Nt = len(time)
+        da = xr.DataArray(np.arange(len(time)), dims='time',
+                                    coords=[time])
+        ft = xrft.dft(da, shift=False)
         dt = np.diff(time)[0].total_seconds()
         freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -177,7 +177,7 @@ class TestDFTImag(object):
                                     coords=[time])
 
         ft = xrft.dft(da, shift=False)
-        # num = cftime.date2num(time,'hours since 1800-01-01 00:00:00','noleap')
+        
         dt = np.diff(time)[0].total_seconds()
         freq_time_expected = np.fft.fftfreq(Nt, dt)
         npt.assert_allclose(ft['freq_time'], freq_time_expected)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -250,7 +250,7 @@ def _new_dims_and_coords(da, axis_num, dim, wavenm, prefix):
     return newdims, newcoords
 
 def _maybe_decode_time(coord):
-    """Returns decoded time as a xarray.DataArray."""
+    """Returns the difference as a xarray.DataArray."""
 
     v0 = coord.values[0]
     calendar = getattr(v0, 'calendar', None)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -249,7 +249,7 @@ def _new_dims_and_coords(da, axis_num, dim, wavenm, prefix):
 
     return newdims, newcoords
 
-def _maybe_decode_time(coord):
+def _diff_coord(coord):
     """Returns the difference as a xarray.DataArray."""
 
     v0 = coord.values[0]
@@ -358,7 +358,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     # verify even spacing of input coordinates
     delta_x = []
     for d in dim:
-        diff = _maybe_decode_time(da[d])
+        diff = _diff_coord(da[d])
         delta = np.abs(diff[0])
         if not np.allclose(diff, diff[0], rtol=spacing_tol):
             raise ValueError("Can't take Fourier transform because "

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -344,10 +344,14 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     for d in dim:
         coord = da[d]
         if type(coord.values[0]) == cftime._cftime.DatetimeNoLeap:
-            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00','noleap')
+            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                    'noleap')
         elif type(coord.values[0]) == cftime._cftime.DatetimeGregorian:
             coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
-                                    calendar='standard')
+                                    'standard')
+        elif type(coord.values[0]) == cftime._cftime.DatetimeJulian:
+            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                    'julian')
         diff = np.diff(coord)
         if pd.api.types.is_timedelta64_dtype(diff):
             # convert to seconds so we get hertz

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -251,14 +251,20 @@ def _new_dims_and_coords(da, axis_num, dim, wavenm, prefix):
 
 def _maybe_decode_time(coord):
     """Returns decoded time as a xarray.DataArray."""
-    import cftime
 
-    calendar = coord.values[0].calendar
-    ref_units = 'seconds since 1800-01-01 00:00:00'
-    decoded_time = cftime.date2num(coord, ref_units, calendar)
-    coord = xr.DataArray(decoded_time, dims=coord.dims, coords=coord.coords)
+    v0 = coord.values[0]
+    calendar = getattr(v0, 'calendar', None)
+    if calendar:
+        import cftime
+        ref_units = 'seconds since 1800-01-01 00:00:00'
+        decoded_time = cftime.date2num(coord, ref_units, calendar)
+        coord = xr.DataArray(decoded_time, dims=coord.dims, coords=coord.coords)
+        return np.diff(coord)
+    elif pd.api.types.is_datetime64_dtype(v0):
+        return np.diff(coord).astype('timedelta64[s]').astype('f8')
+    else:
+        return np.diff(coord)
 
-    return coord
 
 def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         window=False, chunks_to_segments=False, prefix='freq_'):
@@ -352,15 +358,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     # verify even spacing of input coordinates
     delta_x = []
     for d in dim:
-        coord = da[d]
-        try: # check for cftime coordinates
-            coord = _maybe_decode_time(coord)
-        except:
-            pass
-        diff = np.diff(coord)
-        if pd.api.types.is_timedelta64_dtype(diff):
-            # convert to seconds so we get hertz
-            diff = diff.astype('timedelta64[s]').astype('f8')
+        diff = _maybe_decode_time(da[d])
         delta = np.abs(diff[0])
         if not np.allclose(diff, diff[0], rtol=spacing_tol):
             raise ValueError("Can't take Fourier transform because "

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -250,6 +250,21 @@ def _new_dims_and_coords(da, axis_num, dim, wavenm, prefix):
 
     return newdims, newcoords
 
+def _cftime(coord):
+    if type(coord.values[0]) == cftime._cftime.DatetimeNoLeap:
+        coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                'noleap')
+    elif type(coord.values[0]) == cftime._cftime.DatetimeGregorian:
+        coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                'standard')
+    elif type(coord.values[0]) == cftime._cftime.DatetimeJulian:
+        coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                'julian')
+    elif type(coord.values[0]) == cftime._cftime.Datetime360Day:
+        coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                '360_day')
+    return coord
+
 def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         window=False, chunks_to_segments=False, prefix='freq_'):
     """
@@ -342,19 +357,7 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     # verify even spacing of input coordinates
     delta_x = []
     for d in dim:
-        coord = da[d]
-        if type(coord.values[0]) == cftime._cftime.DatetimeNoLeap:
-            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
-                                    'noleap')
-        elif type(coord.values[0]) == cftime._cftime.DatetimeGregorian:
-            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
-                                    'standard')
-        elif type(coord.values[0]) == cftime._cftime.DatetimeJulian:
-            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
-                                    'julian')
-        elif type(coord.values[0]) == cftime._cftime.Datetime360Day:
-            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
-                                    '360_day')
+        coord = _cftime(da[d])
         diff = np.diff(coord)
         if pd.api.types.is_timedelta64_dtype(diff):
             # convert to seconds so we get hertz

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -7,6 +7,8 @@ from functools import reduce
 import numpy as np
 import xarray as xr
 import pandas as pd
+import cftime
+import datetime
 
 import dask.array as dsar
 from dask import delayed
@@ -342,6 +344,8 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
     delta_x = []
     for d in dim:
         coord = da[d]
+        if type(coord.values[0]) == cftime._cftime.DatetimeNoLeap:
+            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00','noleap')
         diff = np.diff(coord)
         if pd.api.types.is_timedelta64_dtype(diff):
             # convert to seconds so we get hertz

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -8,7 +8,6 @@ import numpy as np
 import xarray as xr
 import pandas as pd
 import cftime
-import datetime
 
 import dask.array as dsar
 from dask import delayed

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -345,6 +345,9 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         coord = da[d]
         if type(coord.values[0]) == cftime._cftime.DatetimeNoLeap:
             coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00','noleap')
+        elif type(coord.values[0]) == cftime._cftime.DatetimeGregorian:
+            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                    calendar='standard')
         diff = np.diff(coord)
         if pd.api.types.is_timedelta64_dtype(diff):
             # convert to seconds so we get hertz

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -352,6 +352,9 @@ def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         elif type(coord.values[0]) == cftime._cftime.DatetimeJulian:
             coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
                                     'julian')
+        elif type(coord.values[0]) == cftime._cftime.Datetime360Day:
+            coord = cftime.date2num(coord,'seconds since 1800-01-01 00:00:00',
+                                    '360_day')
         diff = np.diff(coord)
         if pd.api.types.is_timedelta64_dtype(diff):
             # convert to seconds so we get hertz


### PR DESCRIPTION
I added some checks to the `cftime` convention based on #99 but I don't have much confidence whether this is robust enough for other options than `noleap`. If others think this PR is good to merge, I'll merge it and work on releasing a new version #97.