### PR TITLE
Fix normalisation of power spectra density when `chunks_to_segments=True`

### DIFF
--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -265,7 +265,15 @@ def _diff_coord(coord):
     else:
         return np.diff(coord)
 
-
+def _calc_normalization_factor(da, axis_num, chunks_to_segments):
+    """Return the signal length, N, to be used in the normalisation of spectra"""
+    
+    if chunks_to_segments:
+        # Use chunk sizes for normalisation
+        return [da.chunks[n][0] for n in axis_num]
+    else:
+        return [da.shape[n] for n in axis_num]
+    
 def dft(da, spacing_tol=1e-3, dim=None, real=None, shift=True, detrend=None,
         window=False, chunks_to_segments=False, prefix='freq_'):
     """
@@ -453,7 +461,7 @@ def power_spectrum(da, spacing_tol=1e-3, dim=None, real=None, shift=True,
     # the axes along which to take ffts
     axis_num = [da.get_axis_num(d) for d in dim]
 
-    N = [da.shape[n] for n in axis_num]
+    N = _calc_normalization_factor(da, axis_num, chunks_to_segments)
 
     return _power_spectrum(daft, dim, N, density)
 
@@ -535,7 +543,7 @@ def cross_spectrum(da1, da2, spacing_tol=1e-3, dim=None, shift=True,
     # the axes along which to take ffts
     axis_num = [da1.get_axis_num(d) for d in dim]
 
-    N = [da1.shape[n] for n in axis_num]
+    N = _calc_normalization_factor(da1, axis_num, chunks_to_segments)
 
     return _cross_spectrum(daft1, daft2, dim, N, density)
 


### PR DESCRIPTION
# Description

The term `N` in the `density=True` normalisation is computed from the chunk sizes rather than dimension sizes when `chunks_to_segments=True`.

Closes #102

## Type of change

-   [x]  Bug fix (non-breaking change which fixes an issue)

## Testing 

- [x] Extended `test_parseval()` to include checks with `chunks_to_segments=True`