### PR TITLE
[WIP] Make sure xarray.polyfit does not rechunk datarray

### DIFF
--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -141,7 +141,8 @@ def _apply_detrend(da, dim, axis_num, detrend_type):
         if len(dim) == 1:
             p = da.polyfit(dim=dim[0], deg=1)
             linear_fit = xr.polyval(da[dim[0]], p.polyfit_coefficients)
-            return da - linear_fit
+            da_detrended = (da - linear_fit).chunk(da.chunks) # see discussion in https://github.com/xgcm/xrft/issues/116
+            return da_detrended
 
         elif len(dim) > 3:
             raise NotImplementedError("Detrending over more than 4 axes is "


### PR DESCRIPTION
Out of principle, `xrft` should not be rechunking the users input on the background. This PR is a "hack" for what supposed to be an issue with `xarray.polyfit()` (see #116 and https://github.com/pydata/xarray/issues/4554). `xarray.polyfit()` seems to be rechunking the data and `xrft` calls `xarray.polyfit()` when the user asks for a linear detrend of the input of `xrft.dft()`. The proposed change simply makes sure that the detrended data array has the same chunking as the original one.

Closes #116