### PR TITLE
numpy_groupies is now required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
 ]
 
-INSTALL_REQUIRES = ["xarray", "dask", "numpy", "pandas", "scipy"]
-EXTRAS_REQUIRE = ["cftime", "numpy_groupies"]
+INSTALL_REQUIRES = ["xarray", "dask", "numpy", "pandas", "scipy", "numpy_groupies"]
+EXTRAS_REQUIRE = ["cftime"]
 SETUP_REQUIRES = ["pytest-runner"]
 TESTS_REQUIRE = ["pytest >= 2.8", "coverage"]
 


### PR DESCRIPTION
It seems as though `numpy_groupies` is now required in order to run `import xrft` (rather than an extra), so I suggest moving it to `INSTALL_REQUIRES`. 

(suggestions for other possibilities are welcome)