### PR TITLE
Making numpy_groupies an extra requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
 ]
 
-INSTALL_REQUIRES = ["xarray", "dask", "numpy", "pandas", "scipy"]
-EXTRAS_REQUIRE = ["cftime", "numpy_groupies"]
+INSTALL_REQUIRES = ["xarray", "dask", "numpy", "pandas", "scipy", "numpy_groupies"]
+EXTRAS_REQUIRE = ["cftime"]
 SETUP_REQUIRES = ["pytest-runner"]
 TESTS_REQUIRE = ["pytest >= 2.8", "coverage"]
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -5,7 +5,6 @@ import functools as ft
 from functools import reduce
 
 import numpy as np
-import numpy_groupies
 import xarray as xr
 import pandas as pd
 
@@ -782,6 +781,9 @@ def _binned_agg(
     dtype,
 ) -> np.ndarray:
     """NumPy helper function for aggregating over bins."""
+
+    import numpy_groupies
+
     mask = np.logical_not(np.isnan(indices))
     int_indices = indices[mask].astype(int)
     shape = array.shape[: -indices.ndim] + (num_bins,)


### PR DESCRIPTION
This addresses PR #132 . I moved `import numpy_groupies` to only when `isotropic` functions are called.