### PR TITLE
Making FFT conventions similar to scipy

### DIFF
--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -409,7 +409,7 @@ class TestSpectrum(object):
 
         with pytest.raises(ValueError):
             xrft.power_spectrum(
-                da, dim=["y", "x"], window=False, correct_amplitude=True
+                da, dim=["y", "x"], window=False, boost_amplitude=True
             )
 
     @pytest.mark.parametrize("dask", [False, True])
@@ -458,7 +458,7 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(cs).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.cross_spectrum(da, da2, dim=dim, window=False, correct_amplitude=True)
+            xrft.cross_spectrum(da, da2, dim=dim, window=False, boost_amplitude=True)
 
     def test_spectrum_dim(self):
         N = 16

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -387,7 +387,7 @@ class TestSpectrum(object):
                 dim=["t"],
                 window=window_type,
                 chunks_to_segments=True,
-                boost_windowed_amplitude=True,
+                window_correction=True,
             ).mean("t_segment")
 
             npt.assert_allclose(
@@ -442,9 +442,7 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.power_spectrum(
-                da, dim=["y", "x"], window=None, boost_windowed_amplitude=True
-            )
+            xrft.power_spectrum(da, dim=["y", "x"], window=None, window_correction=True)
 
     @pytest.mark.parametrize("dask", [False, True])
     def test_cross_spectrum(self, dask):
@@ -492,9 +490,7 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(cs).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.cross_spectrum(
-                da, da2, dim=dim, window=None, boost_windowed_amplitude=True
-            )
+            xrft.cross_spectrum(da, da2, dim=dim, window=None, window_correction=True)
 
     def test_spectrum_dim(self):
         N = 16

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -650,14 +650,22 @@ def test_parseval(chunks_to_segments):
     )
 
     # Check that the (rectangular) integral of the spectrum matches the windowed variance
-    # for i in dim:
-    #     da_corrected = (da_prime * window) ** 2 / np.mean(np.hanning(N / n_segments)**2)
     npt.assert_almost_equal(
         (1 / delta_xy) * ps.mean(fftdim).values,
         ((da_prime * window) ** 2).mean(dim).values,
-        # da_corrected.mean(dim).values,
         decimal=5,
     )
+
+    # ps = xrft.power_spectrum(
+    #     da, window=True, detrend="constant", chunks_to_segments=chunks_to_segments, correct_amplitude=True
+    # )
+    # da_corrected = (da_prime * window) ** 2 / (window**2).mean()
+    # npt.assert_almost_equal(
+    #     (1 / delta_xy) * ps.mean(fftdim).values,
+    #     ((da_prime * window) ** 2).mean(dim).values,
+    #     da_corrected.mean(dim).values,
+    #     decimal=2,
+    # )
 
     ### Test Parseval's theorem for cross_spectrum with `window=True` and detrend='constant'
     cs = xrft.cross_spectrum(
@@ -670,7 +678,6 @@ def test_parseval(chunks_to_segments):
     npt.assert_almost_equal(
         (1 / delta_xy) * cs.mean(fftdim).values,
         ((da_prime * window) * (da2_prime * window)).mean(dim).values,
-        # ((da_prime) * (da2_prime)).mean(dim).values,
         decimal=5,
     )
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -367,7 +367,7 @@ class TestSpectrum(object):
         f_scipy, p_scipy = sps.periodogram(
             da.values, window="rectangular", return_onesided=True
         )
-        ps = xrft.xrft.power_spectrum(da, dim="x", real="x", detrend="constant")
+        ps = xrft.power_spectrum(da, dim="x", real="x", detrend="constant")
         npt.assert_almost_equal(ps.values, p_scipy)
 
         A = 20
@@ -382,7 +382,7 @@ class TestSpectrum(object):
             # see https://github.com/scipy/scipy/blob/master/scipy/signal/tests/test_spectral.py#L485
 
             x_da = xr.DataArray(x, coords=[tt], dims=["t"]).chunk({"t": n_segments})
-            ps = xrft.xrft.power_spectrum(
+            ps = xrft.power_spectrum(
                 x_da,
                 dim="t",
                 window=window_type,
@@ -396,7 +396,7 @@ class TestSpectrum(object):
                 rtol=1e-3,
             )
 
-            ps = xrft.xrft.power_spectrum(
+            ps = xrft.power_spectrum(
                 x_da,
                 dim="t",
                 window=window_type,

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -123,7 +123,6 @@ class TestFFTImag(object):
 
         ft = xrft.fft(da, shift=False, window="hann", detrend="constant")
         dim = da.dims
-        # window = np.hanning(N) * np.hanning(N)[:, np.newaxis]
         window = sps.windows.hann(N) * sps.windows.hann(N)[:, np.newaxis]
         da_prime = (da - da.mean(dim=dim)).values
         npt.assert_almost_equal(ft.values, np.fft.fftn(da_prime * window))
@@ -693,17 +692,6 @@ def test_parseval(chunks_to_segments):
         ((da_prime * window) ** 2).mean(dim).values,
         decimal=5,
     )
-
-    # ps = xrft.power_spectrum(
-    #     da, window=True, detrend="constant", chunks_to_segments=chunks_to_segments, correct_amplitude=True
-    # )
-    # da_corrected = (da_prime * window) ** 2 / (window**2).mean()
-    # npt.assert_almost_equal(
-    #     (1 / delta_xy) * ps.mean(fftdim).values,
-    #     ((da_prime * window) ** 2).mean(dim).values,
-    #     da_corrected.mean(dim).values,
-    #     decimal=2,
-    # )
 
     ### Test Parseval's theorem for cross_spectrum with `window=True` and detrend='constant'
     cs = xrft.cross_spectrum(

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -383,15 +383,15 @@ class TestSpectrum(object):
 
             x_da = xr.DataArray(x, coords=[tt], dims=["t"]).chunk({"t": n_segments})
             ps = xrft.xrft.power_spectrum(
-                x_da, dim=["t"], window=window_type, chunks_to_segments=True
+                x_da,
+                dim=["t"],
+                window=window_type,
+                chunks_to_segments=True,
+                boost_windowed_amplitude=True,
             ).mean("t_segment")
 
-            corr = 1 / np.mean(
-                getattr(sps.windows, window_type)(n_segments, sym=False) ** 2
-            )
-
             npt.assert_allclose(
-                np.sqrt(np.trapz(corr * ps.values, ps.freq_t.values)),
+                np.sqrt(np.trapz(ps.values, ps.freq_t.values)),
                 A * np.sqrt(2) / 2,
                 rtol=1e-3,
             )

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -212,7 +212,7 @@ class TestfftReal(object):
         dx = float(da.x[1] - da.x[0]) if "x" in da.dims else 1
 
         # defaults with no keyword args
-        ft = xrft.fft(da, real="x", detrend="constant")
+        ft = xrft.fft(da, real_dim="x", detrend="constant")
         # check that the frequency dimension was created properly
         assert ft.dims == ("freq_x",)
         # check that the coords are correct
@@ -230,7 +230,7 @@ class TestfftReal(object):
         npt.assert_allclose(ft_data_expected, ft.values, atol=1e-14)
 
         with pytest.raises(ValueError):
-            xrft.fft(da, real="y", detrend="constant")
+            xrft.fft(da, real_dim="y", detrend="constant")
 
     def test_fft_real_2d(self):
         """
@@ -247,11 +247,11 @@ class TestfftReal(object):
         dx = float(da.x[1] - da.x[0])
         dy = float(da.y[1] - da.y[0])
 
-        daft = xrft.fft(da, real="x")
+        daft = xrft.fft(da, real_dim="x")
         npt.assert_almost_equal(
             daft.values, np.fft.rfftn(da.transpose("y", "x")).transpose()
         )
-        npt.assert_almost_equal(daft.values, xrft.fft(da, dim=["y"], real="x"))
+        npt.assert_almost_equal(daft.values, xrft.fft(da, dim=["y"], real_dim="x"))
 
         actual_freq_x = daft.coords["freq_x"].values
         expected_freq_x = np.fft.rfftfreq(Nx, dx)
@@ -367,7 +367,7 @@ class TestSpectrum(object):
         f_scipy, p_scipy = sps.periodogram(
             da.values, window="rectangular", return_onesided=True
         )
-        ps = xrft.power_spectrum(da, dim="x", real="x", detrend="constant")
+        ps = xrft.power_spectrum(da, dim="x", real_dim="x", detrend="constant")
         npt.assert_almost_equal(ps.values, p_scipy)
 
         A = 20
@@ -427,9 +427,14 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.0)
 
         ps = xrft.power_spectrum(
-            da, dim=["y"], real="x", window="hann", density=False, detrend="constant"
+            da,
+            dim=["y"],
+            real_dim="x",
+            window="hann",
+            density=False,
+            detrend="constant",
         )
-        daft = xrft.fft(da, dim=["y"], real="x", detrend="constant", window="hann")
+        daft = xrft.fft(da, dim=["y"], real_dim="x", detrend="constant", window="hann")
         ps_test = np.real(daft * np.conj(daft))
         f = np.full(ps_test.sizes["freq_x"], 2.0)
         f[0], f[-1] = 1.0, 1.0
@@ -517,12 +522,12 @@ class TestSpectrum(object):
         )
 
         ps = xrft.power_spectrum(
-            da, dim="y", real="x", window="hann", detrend="constant"
+            da, dim="y", real_dim="x", window="hann", detrend="constant"
         )
         npt.assert_array_equal(
             ps.values,
             xrft.power_spectrum(
-                da, dim=["y"], real="x", window="hann", detrend="constant"
+                da, dim=["y"], real_dim="x", window="hann", detrend="constant"
             ).values,
         )
         assert ps.dims == ("time", "freq_y", "freq_x")
@@ -1177,7 +1182,7 @@ def test_real_dft_true_phase():
         },
     )
     s1 = xrft.dft(s, dim="x", true_phase=True, shift=True)
-    s2 = xrft.dft(s, real="x", true_phase=True, shift=True)
+    s2 = xrft.dft(s, real_dim="x", true_phase=True, shift=True)
     s1 = np.conj(s1[{"freq_x": slice(None, s1.sizes["freq_x"] // 2 + 1)}])
     s1 = s1.assign_coords(freq_x=-s1["freq_x"]).sortby("freq_x")
     xrt.assert_allclose(s1, s2)

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -442,7 +442,9 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.power_spectrum(da, dim=["y", "x"], window=None, boost_amplitude=True)
+            xrft.power_spectrum(
+                da, dim=["y", "x"], window=None, boost_windowed_amplitude=True
+            )
 
     @pytest.mark.parametrize("dask", [False, True])
     def test_cross_spectrum(self, dask):
@@ -490,7 +492,9 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(cs).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.cross_spectrum(da, da2, dim=dim, window=None, boost_amplitude=True)
+            xrft.cross_spectrum(
+                da, da2, dim=dim, window=None, boost_windowed_amplitude=True
+            )
 
     def test_spectrum_dim(self):
         N = 16

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -378,17 +378,8 @@ class TestSpectrum(object):
 
         tt = np.arange(fs) / fs
         x = A * np.sin(2 * np.pi * fsig * tt)
-        for window_type in ["hann", "bartlett", "flattop"]:
+        for window_type in ["hann", "bartlett", "tukey", "flattop"]:
             # see https://github.com/scipy/scipy/blob/master/scipy/signal/tests/test_spectral.py#L485
-            freq, p_scipy = sps.welch(
-                x,
-                fs=fs,
-                nperseg=n_segments,
-                window=window_type,
-                noverlap=0,
-                return_onesided=False,
-                scaling="density",
-            )
 
             x_da = xr.DataArray(x, coords=[tt], dims=["t"]).chunk({"t": n_segments})
             ps = xrft.xrft.power_spectrum(

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -408,9 +408,7 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.0)
 
         with pytest.raises(ValueError):
-            xrft.power_spectrum(
-                da, dim=["y", "x"], window=False, boost_amplitude=True
-            )
+            xrft.power_spectrum(da, dim=["y", "x"], window=False, boost_amplitude=True)
 
     @pytest.mark.parametrize("dask", [False, True])
     def test_cross_spectrum(self, dask):

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -365,7 +365,7 @@ class TestSpectrum(object):
             da.values, window="rectangular", return_onesided=True
         )
         ps = xrft.xrft.power_spectrum(da, dim="x", real="x", detrend="constant")
-        npt.assert_almost_equal(ps.values[1:-1], p_scipy[1:-1])
+        npt.assert_almost_equal(ps.values, p_scipy)
         da = xr.DataArray(
             np.random.rand(2, N, N),
             dims=["time", "y", "x"],
@@ -388,7 +388,11 @@ class TestSpectrum(object):
             da, dim=["y"], real="x", window=True, density=False, detrend="constant"
         )
         daft = xrft.fft(da, dim=["y"], real="x", detrend="constant", window=True)
-        npt.assert_almost_equal(ps.values, 2 * np.real(daft * np.conj(daft)))
+        ps_test = np.real(daft * np.conj(daft))
+        f = np.full(ps_test.sizes["freq_x"], 2.0)
+        f[0], f[-1] = 1.0, 1.0
+        ps_test = ps_test * xr.DataArray(f, dims="freq_x")
+        npt.assert_almost_equal(ps.values, ps_test.values)
 
         ### Normalized
         ps = xrft.power_spectrum(da, dim=["y", "x"], window=True, detrend="constant")

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -359,17 +359,12 @@ class TestSpectrum(object):
             dims=["x"],
             coords={
                 "x": range(N),
-            }
+            },
         )
-        f_scipy, p_scipy = sps.periodogram(da.values,
-                                           window='rectangular',
-                                           return_onesided=True
-                                           )
-        ps = xrft.xrft.power_spectrum(da,
-                                      dim='x',
-                                      real='x',
-                                      detrend='constant'
-                                      )
+        f_scipy, p_scipy = sps.periodogram(
+            da.values, window="rectangular", return_onesided=True
+        )
+        ps = xrft.xrft.power_spectrum(da, dim="x", real="x", detrend="constant")
         npt.assert_almost_equal(ps.values[1:-1], p_scipy[1:-1])
         da = xr.DataArray(
             np.random.rand(2, N, N),
@@ -378,7 +373,7 @@ class TestSpectrum(object):
                 "time": np.array(["2019-04-18", "2019-04-19"], dtype="datetime64"),
                 "y": range(N),
                 "x": range(N),
-            }
+            },
         )
         if dask:
             da = da.chunk({"time": 1})
@@ -393,7 +388,7 @@ class TestSpectrum(object):
             da, dim=["y"], real="x", window=True, density=False, detrend="constant"
         )
         daft = xrft.fft(da, dim=["y"], real="x", detrend="constant", window=True)
-        npt.assert_almost_equal(ps.values, 2*np.real(daft * np.conj(daft)))
+        npt.assert_almost_equal(ps.values, 2 * np.real(daft * np.conj(daft)))
 
         ### Normalized
         ps = xrft.power_spectrum(da, dim=["y", "x"], window=True, detrend="constant")
@@ -469,9 +464,7 @@ class TestSpectrum(object):
             },
         )
 
-        ps = xrft.power_spectrum(
-            da, dim="y", real="x", window=True, detrend="constant"
-        )
+        ps = xrft.power_spectrum(da, dim="y", real="x", window=True, detrend="constant")
         npt.assert_array_equal(
             ps.values,
             xrft.power_spectrum(

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -393,7 +393,9 @@ class TestSpectrum(object):
                 chunks_to_segments=True,
             ).mean("x_segment")
             ps_corrected = ps / np.mean(sps.windows.hann(n_segment) ** 2)
-            npt.assert_allclose(ps_corrected.values, np.fft.fftshift(p_scipy), atol=1e-2)
+            npt.assert_allclose(
+                ps_corrected.values, np.fft.fftshift(p_scipy), atol=1e-2
+            )
 
         da = xr.DataArray(
             np.random.rand(2, N, N),

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -684,7 +684,7 @@ def power_spectrum(
             if kwargs[arg] is None:
                 raise ValueError("Windowing needs to be turned on.")
             else:
-                windows, _ = _apply_window(da, dim, window_type=window)
+                windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
                 ps = ps / (windows ** 2).mean()
 
     if scaling == "density":
@@ -786,7 +786,7 @@ def cross_spectrum(
             if kwargs[arg] is None:
                 raise ValueError("Windowing needs to be turned on.")
             else:
-                windows, _ = _apply_window(da, dim, window_type=window)
+                windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
                 cs = cs / (windows ** 2).mean()
 
     if scaling == "density":

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -684,32 +684,24 @@ def power_spectrum(
 
     if scaling == "density":
         if window_correction:
-            for arg in kwargs.keys():
-                if arg == "window":
-                    if kwargs[arg] is None:
-                        raise ValueError(
-                            "window_correction can only be applied when windowing is turned on."
-                        )
-                    else:
-                        msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
-                        warnings.warn(msg, Warning)
-                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
-                        ps = ps / (windows ** 2).mean()
+            if kwargs.get("window") == None:
+                raise ValueError(
+                    "window_correction can only be applied when windowing is turned on."
+                )
+            else:
+                windows, _ = _apply_window(da, dim, window_type=kwargs.get("window"))
+                ps = ps / (windows ** 2).mean()
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
         ps *= fs
     elif scaling == "spectrum":
         if window_correction:
-            for arg in kwargs.keys():
-                if arg == "window":
-                    if kwargs[arg] is None:
-                        raise ValueError(
-                            "window_correction can only be applied when windowing is turned on."
-                        )
-                    else:
-                        msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
-                        warnings.warn(msg, Warning)
-                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
-                        ps = ps / windows.mean() ** 2
+            if kwargs.get("window") == None:
+                raise ValueError(
+                    "window_correction can only be applied when windowing is turned on."
+                )
+            else:
+                windows, _ = _apply_window(da, dim, window_type=kwargs.get("window"))
+                ps = ps / windows.mean() ** 2
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
         ps *= fs ** 2
     elif scaling == "false_density":  # Corresponds to density=False
@@ -805,32 +797,24 @@ def cross_spectrum(
 
     if scaling == "density":
         if window_correction:
-            for arg in kwargs.keys():
-                if arg == "window":
-                    if kwargs[arg] is None:
-                        raise ValueError(
-                            "window_correction can only be applied when windowing is turned on."
-                        )
-                    else:
-                        msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
-                        warnings.warn(msg, Warning)
-                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
-                        cs = cs / (windows ** 2).mean()
+            if kwargs.get("window") == None:
+                raise ValueError(
+                    "window_correction can only be applied when windowing is turned on."
+                )
+            else:
+                windows, _ = _apply_window(da, dim, window_type=kwargs.get("window"))
+                cs = cs / (windows ** 2).mean()
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])
         cs *= fs
     elif scaling == "spectrum":
         if window_correction:
-            for arg in kwargs.keys():
-                if arg == "window":
-                    if kwargs[arg] is None:
-                        raise ValueError(
-                            "window_correction can only be applied when windowing is turned on."
-                        )
-                    else:
-                        msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
-                        warnings.warn(msg, Warning)
-                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
-                        cs = cs / windows.mean() ** 2
+            if kwargs.get("window") == None:
+                raise ValueError(
+                    "window_correction can only be applied when windowing is turned on."
+                )
+            else:
+                windows, _ = _apply_window(da, dim, window_type=kwargs.get("window"))
+                cs = cs / windows.mean() ** 2
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])
         cs *= fs ** 2
     elif scaling == "false_density":  # Corresponds to density=False
@@ -1036,7 +1020,7 @@ def isotropic_power_spectrum(
         the FT.
     density : list, optional
         If true, it will normalize the spectrum to spectral density
-    window : bool, optional
+    window : str, optional
         Whether to apply a window to the data before the Fourier
         transform is taken. Please adhere to scipy.signal.windows for naming convention.
     nfactor : int, optional
@@ -1125,7 +1109,7 @@ def isotropic_cross_spectrum(
         the FT.
     density : list (optional)
         If true, it will normalize the spectrum to spectral density
-    window : bool (optional)
+    window : str (optional)
         Whether to apply a window to the data before the Fourier
         transform is taken. Please adhere to scipy.signal.windows for naming convention.
     nfactor : int (optional)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -643,7 +643,9 @@ def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwa
 
     for arg in kwargs.keys():
         if arg == "real" and kwargs[arg] is not None:
-            ps = ps * 2
+            f = np.full(ps.sizes["freq_" + kwargs[arg]], 2.0)
+            f[0], f[-1] = 1.0, 1.0
+            ps = ps * xr.DataArray(f, dims="freq_" + kwargs[arg])
         if arg == "window" and boost_amplitude:
             if kwargs[arg] is not True:
                 raise ValueError("Windowing needs to be turned on.")
@@ -726,7 +728,9 @@ def cross_spectrum(
 
     for arg in kwargs.keys():
         if arg == "real" and kwargs[arg] is not None:
-            cs = cs * 2
+            f = np.full(cs.sizes["freq_" + kwargs[arg]], 2.0)
+            f[0], f[-1] = 1.0, 1.0
+            cs = cs * xr.DataArray(f, dims="freq_" + kwargs[arg])
         if arg == "window" and boost_amplitude:
             if kwargs[arg] is not True:
                 raise ValueError("Windowing needs to be turned on.")

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -644,6 +644,8 @@ def power_spectrum(
     window_correction : boolean
         If True, it will correct for the energy reduction resulting from applying a non-uniform window.
         This is the default behaviour of many tools for computing power spectrum (e.g scipy.signal.welch and scipy.signal.periodogram).
+        If scaling = 'spectrum', correct the amplitude of peaks in the spectrum. This ensures, for example, that the peak in the one-sided power spectrum of a 10 Hz sine wave with RMS**2 = 10 has a magnitude of 10.
+        If scaling = 'density', correct for the energy (integral) of the spectrum. This ensures, for example, that the power spectral density integrates to the square of the RMS of the signal (ie that Parseval's theorem is satisfied). Note that in most cases, Parseval's theorem will only be approximately satisfied with this correction as it assumes that the signal being windowed is independent of the window. The correction becomes more accurate as the width of the window gets large in comparison with any noticeable period in the signal.
         If False, the spectrum gives a representation of the power in the windowed signal.
         Note that when True, Parseval's theorem may only be approximately satisfied.
     kwargs : dict : see xrft.dft for argument list
@@ -685,7 +687,9 @@ def power_spectrum(
             for arg in kwargs.keys():
                 if arg == "window":
                     if kwargs[arg] is None:
-                        raise ValueError("Windowing needs to be turned on.")
+                        raise ValueError(
+                            "window_correction can only be applied when windowing is turned on."
+                        )
                     else:
                         msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
                         warnings.warn(msg, Warning)
@@ -698,7 +702,9 @@ def power_spectrum(
             for arg in kwargs.keys():
                 if arg == "window":
                     if kwargs[arg] is None:
-                        raise ValueError("Windowing needs to be turned on.")
+                        raise ValueError(
+                            "window_correction can only be applied when windowing is turned on."
+                        )
                     else:
                         msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
                         warnings.warn(msg, Warning)
@@ -747,6 +753,8 @@ def cross_spectrum(
     window_correction : boolean
         If True, it will correct for the energy reduction resulting from applying a non-uniform window.
         This is the default behaviour of many tools for computing power spectrum (e.g scipy.signal.welch and scipy.signal.periodogram).
+        If scaling = 'spectrum', correct the amplitude of peaks in the spectrum. This ensures, for example, that the peak in the one-sided power spectrum of a 10 Hz sine wave with RMS**2 = 10 has a magnitude of 10.
+        If scaling = 'density', correct for the energy (integral) of the spectrum. This ensures, for example, that the power spectral density integrates to the square of the RMS of the signal (ie that Parseval's theorem is satisfied). Note that in most cases, Parseval's theorem will only be approximately satisfied with this correction as it assumes that the signal being windowed is independent of the window. The correction becomes more accurate as the width of the window gets large in comparison with any noticeable period in the signal.
         If False, the spectrum gives a representation of the power in the windowed signal.
         Note that when True, Parseval's theorem may only be approximately satisfied.
     kwargs : dict : see xrft.dft for argument list
@@ -800,7 +808,9 @@ def cross_spectrum(
             for arg in kwargs.keys():
                 if arg == "window":
                     if kwargs[arg] is None:
-                        raise ValueError("Windowing needs to be turned on.")
+                        raise ValueError(
+                            "window_correction can only be applied when windowing is turned on."
+                        )
                     else:
                         msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
                         warnings.warn(msg, Warning)
@@ -813,7 +823,9 @@ def cross_spectrum(
             for arg in kwargs.keys():
                 if arg == "window":
                     if kwargs[arg] is None:
-                        raise ValueError("Windowing needs to be turned on.")
+                        raise ValueError(
+                            "window_correction can only be applied when windowing is turned on."
+                        )
                     else:
                         msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
                         warnings.warn(msg, Warning)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -697,7 +697,13 @@ def power_spectrum(
 
 
 def cross_spectrum(
-    da1, da2, dim=None, real=None, scaling="density", boost_windowed_amplitude=False, **kwargs
+    da1,
+    da2,
+    dim=None,
+    real=None,
+    scaling="density",
+    boost_windowed_amplitude=False,
+    **kwargs,
 ):
     """
     Calculates the cross spectra of da1 and da2.

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -680,7 +680,7 @@ def power_spectrum(
             f[0], f[-1] = 1.0, 1.0
         else:
             f[0] = 1.0
-        ps = ps * xr.DataArray(f, dims=real)
+        ps = ps * xr.DataArray(f, dims=real, coords=ps[real].coords)
 
     if scaling == "density":
         if window_correction:
@@ -793,7 +793,7 @@ def cross_spectrum(
             f[0], f[-1] = 1.0, 1.0
         else:
             f[0] = 1.0
-        cs = cs * xr.DataArray(f, dims=real)
+        cs = cs * xr.DataArray(f, dims=real, coords=cs[real].coords)
 
     if scaling == "density":
         if window_correction:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -663,7 +663,11 @@ def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwa
 
     for arg in kwargs.keys():
         if arg == "real" and kwargs[arg] is not None:
-            real_dim = [d for d in updated_dims if kwargs[arg]==d[-len(kwargs[arg]):]][0] # find transformed real dimension
+            real_dim = [
+                d for d in updated_dims if kwargs[arg] == d[-len(kwargs[arg]) :]
+            ][
+                0
+            ]  # find transformed real dimension
             f = np.full(ps.sizes[real_dim], 2.0)
             f[0], f[-1] = 1.0, 1.0
             ps = ps * xr.DataArray(f, dims=real_dim)
@@ -751,7 +755,11 @@ def cross_spectrum(
 
     for arg in kwargs.keys():
         if arg == "real" and kwargs[arg] is not None:
-            real_dim = [d for d in updated_dims if kwargs[arg]==d[-len(kwargs[arg]):]][0] # find transformed real dimension
+            real_dim = [
+                d for d in updated_dims if kwargs[arg] == d[-len(kwargs[arg]) :]
+            ][
+                0
+            ]  # find transformed real dimension
             f = np.full(cs.sizes[real_dim], 2.0)
             f[0], f[-1] = 1.0, 1.0
             cs = cs * xr.DataArray(f, dims=real_dim)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -44,7 +44,12 @@ def _fft_module(da):
 def _apply_window(da, dims, window_type="hann"):
     """Creating windows in dimensions dims."""
 
-    if window_type not in [
+    if window_type == True:
+        window_type = "hann"
+        warnings.warn(
+            "Please provide the name of window adhering to scipy.signal.windows. The boolean option will be deprecated in future releases."
+        )
+    elif window_type not in [
         "hann",
         "hamming",
         "kaiser",

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -650,7 +650,7 @@ def power_spectrum(da, dim=None, real=None, scaling="density", **kwargs):
     ps = np.abs(daft) ** 2
 
     if real is not None:
-        ps = ps*2
+        ps = ps * 2
 
     if scaling == "density":
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
@@ -724,7 +724,7 @@ def cross_spectrum(da1, da2, dim=None, real=None, scaling="density", **kwargs):
     cs = daft1 * np.conj(daft2)
 
     if real is not None:
-        cs = cs*2
+        cs = cs * 2
 
     if scaling == "density":
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -615,7 +615,7 @@ def idft(
 
 
 def power_spectrum(
-    da, dim=None, real=None, scaling="density", boost_amplitude=False, **kwargs
+    da, dim=None, real=None, scaling="density", boost_windowed_amplitude=False, **kwargs
 ):
     """
     Calculates the power spectrum of da.
@@ -637,7 +637,7 @@ def power_spectrum(
     scaling : str, optional
         If 'density', it will normalize the output to power spectral density
         If 'spectrum', it will normalize the output to power spectrum
-    boost_amplitude : boolean
+    boost_windowed_amplitude : boolean
         If True, it will correct for the amplitude change by the windowing.
         Note that the Parseval's identity is strictly only satisfied for non-corrected
         spectrum and the windowed data if windowing is applied.
@@ -676,7 +676,7 @@ def power_spectrum(
         ps = ps * xr.DataArray(f, dims=real_dim)
 
     for arg in kwargs.keys():
-        if arg == "window" and boost_amplitude:
+        if arg == "window" and boost_windowed_amplitude:
             if kwargs[arg] is None:
                 raise ValueError("Windowing needs to be turned on.")
             else:
@@ -697,7 +697,7 @@ def power_spectrum(
 
 
 def cross_spectrum(
-    da1, da2, dim=None, real=None, scaling="density", boost_amplitude=False, **kwargs
+    da1, da2, dim=None, real=None, scaling="density", boost_windowed_amplitude=False, **kwargs
 ):
     """
     Calculates the cross spectra of da1 and da2.
@@ -721,7 +721,7 @@ def cross_spectrum(
     scaling : str, optional
         If 'density', it will normalize the output to power spectral density
         If 'spectrum', it will normalize the output to power spectrum
-    boost_amplitude : boolean
+    boost_windowed_amplitude : boolean
         If True, it will correct for the amplitude change by the windowing.
         Note that the Parseval's identity is strictly only satisfied for non-corrected
         spectrum and the windowed data if windowing is applied.
@@ -772,7 +772,7 @@ def cross_spectrum(
         cs = cs * xr.DataArray(f, dims=real_dim)
 
     for arg in kwargs.keys():
-        if arg == "window" and boost_amplitude:
+        if arg == "window" and boost_windowed_amplitude:
             if kwargs[arg] is None:
                 raise ValueError("Windowing needs to be turned on.")
             else:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -63,7 +63,7 @@ def _apply_window(da, dims, window_type="hanning"):
         for d in dims
     ]
 
-    return windows, da * reduce(operator.mul, windows[::-1])
+    return reduce(operator.mul, windows[::-1]), da * reduce(operator.mul, windows[::-1])
 
 
 def _stack_chunks(da, dim, suffix="_segment"):
@@ -649,8 +649,7 @@ def power_spectrum(da, dim=None, scaling="density", correct_amplitude=False, **k
                 raise ValueError("Windowing needs to be turned on.")
             else:
                 windows, _ = _apply_window(da, dim)
-                for i in range(len(windows)):
-                    ps = ps / (windows[i] ** 2).mean()
+                ps = ps / (windows ** 2).mean()
 
     if scaling == "density":
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
@@ -733,8 +732,7 @@ def cross_spectrum(
                 raise ValueError("Windowing needs to be turned on.")
             else:
                 windows, _ = _apply_window(da, dim)
-                for i in range(len(windows)):
-                    cs = cs / (windows[i] ** 2).mean()
+                cs = cs / (windows ** 2).mean()
 
     if scaling == "density":
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -70,10 +70,9 @@ def _apply_window(da, dims, window_type="hann"):
         "nuttall",
     ]:
         raise NotImplementedError(
-            "Please adhere to scipy.signal.windows' naming convention."
+            "Please adhere to scipy.signal.windows for naming convention."
         )
 
-    # numpy_win_func = getattr(np, window_type)
     scipy_win_func = getattr(sps.windows, window_type)
 
     if da.chunks:
@@ -615,7 +614,9 @@ def idft(
     )  # Do nothing if daft was not transposed
 
 
-def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwargs):
+def power_spectrum(
+    da, dim=None, real=None, scaling="density", boost_amplitude=False, **kwargs
+):
     """
     Calculates the power spectrum of da.
 
@@ -695,7 +696,7 @@ def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwa
 
 
 def cross_spectrum(
-    da1, da2, dim=None, scaling="density", boost_amplitude=False, **kwargs
+    da1, da2, dim=None, real=None, scaling="density", boost_amplitude=False, **kwargs
 ):
     """
     Calculates the cross spectra of da1 and da2.
@@ -987,7 +988,7 @@ def isotropic_power_spectrum(
         If true, it will normalize the spectrum to spectral density
     window : bool, optional
         Whether to apply a window to the data before the Fourier
-        transform is taken. Please adhere to scipy.signal.windows' naming convention.
+        transform is taken. Please adhere to scipy.signal.windows for naming convention.
     nfactor : int, optional
         Ratio of number of bins to take the azimuthal averaging with the
         data size. Default is 4.
@@ -1076,7 +1077,7 @@ def isotropic_cross_spectrum(
         If true, it will normalize the spectrum to spectral density
     window : bool (optional)
         Whether to apply a window to the data before the Fourier
-        transform is taken. Please adhere to scipy.signal.windows' naming convention.
+        transform is taken. Please adhere to scipy.signal.windows for naming convention.
     nfactor : int (optional)
         Ratio of number of bins to take the azimuthal averaging with the
         data size. Default is 4.

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -67,6 +67,7 @@ def _apply_window(da, dims, window_type="hann"):
         "general_gaussian",
         "general_hamming",
         "triang",
+        "nuttall"
     ]:
         raise NotImplementedError(
             "Please adhere to scipy.signal.windows' naming convention."

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -680,24 +680,30 @@ def power_spectrum(
             f[0] = 1.0
         ps = ps * xr.DataArray(f, dims=real_dim)
 
-    if window_correction:
-        for arg in kwargs.keys():
-            if arg == "window":
-                if kwargs[arg] is None:
-                    raise ValueError("Windowing needs to be turned on.")
-                else:
-                    if scaling == "density":
+    if scaling == "density":
+        if window_correction:
+            for arg in kwargs.keys():
+                if arg == "window":
+                    if kwargs[arg] is None:
+                        raise ValueError("Windowing needs to be turned on.")
+                    else:
                         msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
                         warnings.warn(msg, Warning)
                         windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
                         ps = ps / (windows ** 2).mean()
-                    elif scaling == "spectrum":
-                        pass
-
-    if scaling == "density":
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
         ps *= fs
     elif scaling == "spectrum":
+        if window_correction:
+            for arg in kwargs.keys():
+                if arg == "window":
+                    if kwargs[arg] is None:
+                        raise ValueError("Windowing needs to be turned on.")
+                    else:
+                        msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
+                        warnings.warn(msg, Warning)
+                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
+                        ps = ps / windows.mean() ** 2
         fs = np.prod([float(ps[d].spacing) for d in updated_dims])
         ps *= fs ** 2
     elif scaling == "false_density":  # Corresponds to density=False
@@ -789,24 +795,30 @@ def cross_spectrum(
             f[0] = 1.0
         cs = cs * xr.DataArray(f, dims=real_dim)
 
-    if window_correction:
-        for arg in kwargs.keys():
-            if arg == "window":
-                if kwargs[arg] is None:
-                    raise ValueError("Windowing needs to be turned on.")
-                else:
-                    if scaling == "density":
+    if scaling == "density":
+        if window_correction:
+            for arg in kwargs.keys():
+                if arg == "window":
+                    if kwargs[arg] is None:
+                        raise ValueError("Windowing needs to be turned on.")
+                    else:
                         msg = "Energy correction is applied where the integral of the spectral density (approximately) matches the square of the RMS of the input signal."
                         warnings.warn(msg, Warning)
                         windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
                         cs = cs / (windows ** 2).mean()
-                    elif scaling == "spectrum":
-                        pass
-
-    if scaling == "density":
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])
         cs *= fs
     elif scaling == "spectrum":
+        if window_correction:
+            for arg in kwargs.keys():
+                if arg == "window":
+                    if kwargs[arg] is None:
+                        raise ValueError("Windowing needs to be turned on.")
+                    else:
+                        msg = "Amplitude correction is applied which corrects the amplitude of peaks in the spectrum."
+                        warnings.warn(msg, Warning)
+                        windows, _ = _apply_window(da, dim, window_type=kwargs[arg])
+                        cs = cs / windows.mean() ** 2
         fs = np.prod([float(cs[d].spacing) for d in updated_dims])
         cs *= fs ** 2
     elif scaling == "false_density":  # Corresponds to density=False

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -597,7 +597,7 @@ def idft(
     )  # Do nothing if daft was not transposed
 
 
-def power_spectrum(da, dim=None, scaling="density", correct_amplitude=False, **kwargs):
+def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwargs):
     """
     Calculates the power spectrum of da.
 
@@ -616,7 +616,7 @@ def power_spectrum(da, dim=None, scaling="density", correct_amplitude=False, **k
     scaling : str, optional
         If 'density', it will normalize the output to power spectral density
         If 'spectrum', it will normalize the output to power spectrum
-    correct_amplitude : boolean
+    boost_amplitude : boolean
         If True, it will correct for the amplitude change by the windowing
     kwargs : dict : see xrft.dft for argument list
     """
@@ -644,7 +644,7 @@ def power_spectrum(da, dim=None, scaling="density", correct_amplitude=False, **k
     for arg in kwargs.keys():
         if arg == "real" and arg is not None:
             ps = ps * 2
-        if arg == "window" and correct_amplitude:
+        if arg == "window" and boost_amplitude:
             if arg is not True:
                 raise ValueError("Windowing needs to be turned on.")
             else:
@@ -665,7 +665,7 @@ def power_spectrum(da, dim=None, scaling="density", correct_amplitude=False, **k
 
 
 def cross_spectrum(
-    da1, da2, dim=None, scaling="density", correct_amplitude=False, **kwargs
+    da1, da2, dim=None, scaling="density", boost_amplitude=False, **kwargs
 ):
     """
     Calculates the cross spectra of da1 and da2.
@@ -687,7 +687,7 @@ def cross_spectrum(
     scaling : str, optional
         If 'density', it will normalize the output to power spectral density
         If 'spectrum', it will normalize the output to power spectrum
-    correct_amplitude : boolean
+    boost_amplitude : boolean
         If True, it will correct for the amplitude change by the windowing
     kwargs : dict : see xrft.dft for argument list
     """
@@ -727,7 +727,7 @@ def cross_spectrum(
     for arg in kwargs.keys():
         if arg == "real" and arg is not None:
             cs = cs * 2
-        if arg == "window" and correct_amplitude:
+        if arg == "window" and boost_amplitude:
             if arg is not True:
                 raise ValueError("Windowing needs to be turned on.")
             else:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -77,15 +77,19 @@ def _apply_window(da, dims, window_type="hann"):
 
     if da.chunks:
 
-        def dask_win_func(n):
-            return dsar.from_delayed(delayed(scipy_win_func, pure=True)(n), (n,), float)
+        def dask_win_func(n, sym=False):
+            return dsar.from_delayed(
+                delayed(scipy_win_func, pure=True)(n, sym=sym), (n,), float
+            )
 
         win_func = dask_win_func
     else:
         win_func = scipy_win_func
 
     windows = [
-        xr.DataArray(win_func(len(da[d])), dims=da[d].dims, coords=da[d].coords)
+        xr.DataArray(
+            win_func(len(da[d]), sym=False), dims=da[d].dims, coords=da[d].coords
+        )
         for d in dims
     ]
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -70,7 +70,7 @@ def _apply_window(da, dims, window_type="hann"):
         "nuttall",
     ]:
         raise NotImplementedError(
-            "Please adhere to scipy.signal.windows for naming convention."
+            "Window type {window_type} not supported. Please adhere to scipy.signal.windows for naming convention."
         )
 
     scipy_win_func = getattr(sps.windows, window_type)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -669,7 +669,10 @@ def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwa
                 0
             ]  # find transformed real dimension
             f = np.full(ps.sizes[real_dim], 2.0)
-            f[0], f[-1] = 1.0, 1.0
+            if len(da[kwargs[arg]]) % 2 == 0:
+                f[0], f[-1] = 1.0, 1.0
+            else:
+                f[0] = 1.0
             ps = ps * xr.DataArray(f, dims=real_dim)
         if arg == "window" and boost_amplitude:
             if kwargs[arg] is None:
@@ -761,7 +764,10 @@ def cross_spectrum(
                 0
             ]  # find transformed real dimension
             f = np.full(cs.sizes[real_dim], 2.0)
-            f[0], f[-1] = 1.0, 1.0
+            if len(da1[kwargs[arg]]) % 2 == 0:
+                f[0], f[-1] = 1.0, 1.0
+            else:
+                f[0] = 1.0
             cs = cs * xr.DataArray(f, dims=real_dim)
         if arg == "window" and boost_amplitude:
             if kwargs[arg] is None:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -642,10 +642,10 @@ def power_spectrum(da, dim=None, scaling="density", boost_amplitude=False, **kwa
     ps = np.abs(daft) ** 2
 
     for arg in kwargs.keys():
-        if arg == "real" and arg is not None:
+        if arg == "real" and kwargs[arg] is not None:
             ps = ps * 2
         if arg == "window" and boost_amplitude:
-            if arg is not True:
+            if kwargs[arg] is not True:
                 raise ValueError("Windowing needs to be turned on.")
             else:
                 windows, _ = _apply_window(da, dim)
@@ -725,10 +725,10 @@ def cross_spectrum(
     cs = daft1 * np.conj(daft2)
 
     for arg in kwargs.keys():
-        if arg == "real" and arg is not None:
+        if arg == "real" and kwargs[arg] is not None:
             cs = cs * 2
         if arg == "window" and boost_amplitude:
-            if arg is not True:
+            if kwargs[arg] is not True:
                 raise ValueError("Windowing needs to be turned on.")
             else:
                 windows, _ = _apply_window(da, dim)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -44,8 +44,33 @@ def _fft_module(da):
 def _apply_window(da, dims, window_type="hann"):
     """Creating windows in dimensions dims."""
 
-    # if window_type not in ["hann"]:
-    #     raise NotImplementedError("Only hann window is supported for now.")
+    if window_type not in [
+        "hann",
+        "hamming",
+        "kaiser",
+        "tukey",
+        "parzen",
+        "taylor",
+        "boxcar",
+        "barthann",
+        "bartlett",
+        "blackman",
+        "blackmanharris",
+        "bohman",
+        "chebwin",
+        "cosine",
+        "dpss",
+        "exponential",
+        "flattop",
+        "gaussian",
+        "general_cosine",
+        "general_gaussian",
+        "general_hamming",
+        "triang",
+    ]:
+        raise NotImplementedError(
+            "Please adhere to scipy.signal.windows' naming convention."
+        )
 
     # numpy_win_func = getattr(np, window_type)
     scipy_win_func = getattr(sps.windows, window_type)


### PR DESCRIPTION
A PR to double the power and cross spectrum when `real` is called in order to adhere with `scipy.signal.periodogram(return_onesided=True)` convention. This addresses issue #105 .