### PR TITLE
Energy correction for isotropic spectrum

### DIFF
--- a/doc/DFT-iDFT_example.ipynb
+++ b/doc/DFT-iDFT_example.ipynb
@@ -358,7 +358,7 @@
     "inda_dft.real.plot(ax=ax, linestyle='-', c='k', lw=4, label='phase preservation')\n",
     "ax.plot(x[nshift:], inda_fft.real, linestyle='', marker='+', label='no phase preservation')\n",
     "nda.plot(ax=ax, ls='--', lw=3, label='original signal')\n",
-    "ax.plot(x[nx:], npft.ifft(nda_npft).real, ls=':', label='inverse of numpy fft')\n",
+    "ax.plot(x[nshift:], npft.ifft(nda_npft).real, ls=':', label='inverse of numpy fft')\n",
     "ax.set_xlim([nda.x.min(),nda.x.max()])\n",
     "ax.legend(loc='upper left');"
    ]

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -968,6 +968,14 @@ def test_isotropic_ps_slope(chunk, N=512, dL=1.0, amp=1e1, s=-3.0):
         )
     npt.assert_almost_equal(iso_ps.values, iso_ps_sequal.mean(axis=0))
 
+    iso_ps = xrft.isotropic_power_spectrum(
+        theta, dim=["y", "x"], detrend="constant", scaling="density"
+    ).mean("d0")
+    npt.assert_almost_equal(np.ma.masked_invalid(iso_ps).mask.sum(), 0.0)
+    y_fit, a, b = xrft.fit_loglog(iso_ps.freq_r.values[4:], iso_ps.values[4:])
+    npt.assert_allclose(a, s, atol=0.1)
+    npt.assert_almost_equal(iso_ps.values, iso_ps_sequal.mean(axis=0))
+
 
 @pytest.mark.parametrize("chunk", [False, True])
 def test_isotropic_ps(chunk):

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -1016,7 +1016,7 @@ def isotropic_power_spectrum(
     window_correction=False,
     window=None,
     nfactor=4,
-    **kwargs
+    **kwargs,
 ):
     """
     Calculates the isotropic spectrum from the
@@ -1115,7 +1115,7 @@ def isotropic_cross_spectrum(
     window_correction=False,
     window=None,
     nfactor=4,
-    **kwargs
+    **kwargs,
 ):
     """
     Calculates the isotropic spectrum from the

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -1012,9 +1012,11 @@ def isotropic_power_spectrum(
     dim=None,
     shift=True,
     detrend=None,
-    density=True,
+    scaling="density",
+    window_correction=False,
     window=None,
     nfactor=4,
+    **kwargs
 ):
     """
     Calculates the isotropic spectrum from the
@@ -1059,6 +1061,15 @@ def isotropic_power_spectrum(
     iso_ps : `xarray.DataArray`
         Isotropic power spectrum
     """
+    if "density" in kwargs:
+        density = kwargs.pop("density")
+        msg = (
+            "density flag will be deprecated in future version of xrft.power_spectrum and replaced by scaling flag. "
+            + 'density=True should be replaced by scaling="density" and '
+            + "density=False will not be maintained.\nscaling flag is ignored !"
+        )
+        warnings.warn(msg, FutureWarning)
+        scaling = "density" if density else "false_density"
 
     if dim is None:
         dim = da.dims
@@ -1071,7 +1082,8 @@ def isotropic_power_spectrum(
         dim=dim,
         shift=shift,
         detrend=detrend,
-        density=density,
+        scaling=scaling,
+        window_correction=window_correction,
         window=window,
     )
 
@@ -1099,9 +1111,11 @@ def isotropic_cross_spectrum(
     dim=None,
     shift=True,
     detrend=None,
-    density=True,
+    scaling="density",
+    window_correction=False,
     window=None,
     nfactor=4,
+    **kwargs
 ):
     """
     Calculates the isotropic spectrum from the
@@ -1148,6 +1162,15 @@ def isotropic_cross_spectrum(
     iso_cs : `xarray.DataArray`
         Isotropic cross spectrum
     """
+    if "density" in kwargs:
+        density = kwargs.pop("density")
+        msg = (
+            "density flag will be deprecated in future version of xrft.power_spectrum and replaced by scaling flag. "
+            + 'density=True should be replaced by scaling="density" and '
+            + "density=False will not be maintained.\nscaling flag is ignored !"
+        )
+        warnings.warn(msg, FutureWarning)
+        scaling = "density" if density else "false_density"
 
     if dim is None:
         dim = da1.dims
@@ -1164,7 +1187,8 @@ def isotropic_cross_spectrum(
         dim=dim,
         shift=shift,
         detrend=detrend,
-        density=density,
+        scaling=scaling,
+        window_correction=window_correction,
         window=window,
     )
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -1063,12 +1063,6 @@ def isotropic_power_spectrum(
     """
     if "density" in kwargs:
         density = kwargs.pop("density")
-        msg = (
-            "density flag will be deprecated in future version of xrft.isotropic_power_spectrum and replaced by scaling flag. "
-            + "density=True should be replaced by scaling='density' and "
-            + "density=False will not be maintained.\nscaling flag is ignored !"
-        )
-        warnings.warn(msg, FutureWarning)
         scaling = "density" if density else "false_density"
 
     if dim is None:
@@ -1164,12 +1158,6 @@ def isotropic_cross_spectrum(
     """
     if "density" in kwargs:
         density = kwargs.pop("density")
-        msg = (
-            "density flag will be deprecated in future version of xrft.isotropic_cross_spectrum and replaced by scaling flag. "
-            + "density=True should be replaced by scaling='density' and "
-            + "density=False will not be maintained.\nscaling flag is ignored !"
-        )
-        warnings.warn(msg, FutureWarning)
         scaling = "density" if density else "false_density"
 
     if dim is None:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -1064,8 +1064,8 @@ def isotropic_power_spectrum(
     if "density" in kwargs:
         density = kwargs.pop("density")
         msg = (
-            "density flag will be deprecated in future version of xrft.power_spectrum and replaced by scaling flag. "
-            + 'density=True should be replaced by scaling="density" and '
+            "density flag will be deprecated in future version of xrft.isotropic_power_spectrum and replaced by scaling flag. "
+            + "density=True should be replaced by scaling='density' and "
             + "density=False will not be maintained.\nscaling flag is ignored !"
         )
         warnings.warn(msg, FutureWarning)
@@ -1165,8 +1165,8 @@ def isotropic_cross_spectrum(
     if "density" in kwargs:
         density = kwargs.pop("density")
         msg = (
-            "density flag will be deprecated in future version of xrft.power_spectrum and replaced by scaling flag. "
-            + 'density=True should be replaced by scaling="density" and '
+            "density flag will be deprecated in future version of xrft.isotropic_cross_spectrum and replaced by scaling flag. "
+            + "density=True should be replaced by scaling='density' and "
             + "density=False will not be maintained.\nscaling flag is ignored !"
         )
         warnings.warn(msg, FutureWarning)


### PR DESCRIPTION
Added the flag to allow for energy/amplitude correction for isotropic spectrum as is done for the `power_spectrum()` and `cross_spectrum()`.