### PR TITLE
Force dim to be a list in _apply_window

### DIFF
--- a/xrft/detrend.py
+++ b/xrft/detrend.py
@@ -36,6 +36,12 @@ def detrend(da, dim, detrend_type="constant"):
     input.
     """
 
+    if dim is None:
+        dim = list(da.dims)
+    else:
+        if isinstance(dim, str):
+            dim = [dim]
+
     if detrend_type not in ["constant", "linear", None]:
         raise NotImplementedError(
             "%s is not a valid detrending option. Valid "

--- a/xrft/tests/test_detrend.py
+++ b/xrft/tests/test_detrend.py
@@ -24,6 +24,19 @@ def noise(dims, shape):
     return da
 
 
+@pytest.mark.parametrize("dim", ["t", "time"])
+@pytest.mark.parametrize("detrend_type", ["constant", "linear"])
+def test_dim_format(dim, detrend_type):
+    """ Check that detrend can deal with dim in various formats"""
+    data = xr.DataArray(
+        np.random.random([10]),
+        dims=[dim],
+        coords={dim: range(10)},
+    )
+    dt = detrend(data, dim=dim, detrend_type=detrend_type)
+    dt = detrend(data, dim=[dim], detrend_type=detrend_type)
+
+
 @pytest.mark.parametrize(
     "array_dims, array_shape, detrend_dim, chunks, linear_error",
     (

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -350,6 +350,7 @@ def test_window_single_dim():
     ps = xrft.power_spectrum(data.chunk(), dim=["time"], window="hann")
     ps.load()
 
+
 class TestSpectrum(object):
     @pytest.mark.parametrize("dask", [False, True])
     @pytest.mark.parametrize(
@@ -397,7 +398,7 @@ class TestSpectrum(object):
             ).mean(f"{dim_name}_segment")
             # Check the energy correction
             npt.assert_allclose(
-                np.sqrt(np.trapz(ps.values, ps.freq_t.values)),
+                np.sqrt(np.trapz(ps.values, ps[f"freq_{dim_name}"].values)),
                 A * np.sqrt(2) / 2,
                 rtol=1e-3,
             )
@@ -412,7 +413,7 @@ class TestSpectrum(object):
             ).mean(f"{dim_name}_segment")
             # Check the amplitude correction
             # The factor of 0.5 is there because we're checking the two-sided spectrum
-            npt.assert_allclose(ps.sel(freq_t=fsig), 0.5 * A ** 2 / 2.0)
+            npt.assert_allclose(ps.sel({f"freq_{dim_name}": fsig}), 0.5 * A ** 2 / 2.0)
 
         da = xr.DataArray(
             np.random.rand(2, N, N),

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -351,8 +351,8 @@ def test_window_single_dim():
     ps.load()
 
 class TestSpectrum(object):
-    @pytest.mark.parametrize("dask", [False, True],
-    @pytest.mark.parametrize("dim_name", ["t", "time"])
+    @pytest.mark.parametrize("dask", [False, True])
+    @pytest.mark.parametrize("dim_name", ["t", "time"]) # test single- and multi-character str
     def test_power_spectrum(self, dask, dim_name):
         """Test the power spectrum function"""
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -354,7 +354,7 @@ class TestSpectrum(object):
     @pytest.mark.parametrize("dask", [False, True])
     @pytest.mark.parametrize(
         "dim_name", ["t", "time"]
-    ) # test single- and multi-character str
+    )  # test single- and multi-character str
     def test_power_spectrum(self, dask, dim_name):
         """Test the power spectrum function"""
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -352,7 +352,9 @@ def test_window_single_dim():
 
 class TestSpectrum(object):
     @pytest.mark.parametrize("dask", [False, True])
-    @pytest.mark.parametrize("dim_name", ["t", "time"]) # test single- and multi-character str
+    @pytest.mark.parametrize(
+        "dim_name", ["t", "time"]
+    ) # test single- and multi-character str
     def test_power_spectrum(self, dask, dim_name):
         """Test the power spectrum function"""
 
@@ -367,7 +369,9 @@ class TestSpectrum(object):
         f_scipy, p_scipy = sps.periodogram(
             da.values, window="rectangular", return_onesided=True
         )
-        ps = xrft.power_spectrum(da, dim=dim_name, real_dim=dim_name, detrend="constant")
+        ps = xrft.power_spectrum(
+            da, dim=dim_name, real_dim=dim_name, detrend="constant"
+        )
         npt.assert_almost_equal(ps.values, p_scipy)
 
         A = 20
@@ -381,7 +385,9 @@ class TestSpectrum(object):
         for window_type in ["hann", "bartlett", "tukey", "flattop"]:
             # see https://github.com/scipy/scipy/blob/master/scipy/signal/tests/test_spectral.py#L485
 
-            x_da = xr.DataArray(x, coords=[tt], dims=[dim_name]).chunk({dim_name: n_segments})
+            x_da = xr.DataArray(x, coords=[tt], dims=[dim_name]).chunk(
+                {dim_name: n_segments}
+            )
             ps = xrft.power_spectrum(
                 x_da,
                 dim=dim_name,

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -352,7 +352,7 @@ def test_window_single_dim():
 
 class TestSpectrum(object):
     @pytest.mark.parametrize("dask", [False, True],
-    @pytest.mark.parametrize("dim_name", ["t", "time"]) # test single- and multi-character str
+    @pytest.mark.parametrize("dim_name", ["t", "time"])
     def test_power_spectrum(self, dask, dim_name):
         """Test the power spectrum function"""
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -84,7 +84,7 @@ def _apply_window(da, dims, window_type="hann"):
     else:
         if isinstance(dims, str):
             dims = [dims]
-    
+
     scipy_win_func = getattr(sps.windows, window_type)
 
     if da.chunks:

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -79,6 +79,12 @@ def _apply_window(da, dims, window_type="hann"):
             "Window type {window_type} not supported. Please adhere to scipy.signal.windows for naming convention."
         )
 
+    if dims is None:
+        dims = list(da.dims)
+    else:
+        if isinstance(dims, str):
+            dims = [dims]
+    
     scipy_win_func = getattr(sps.windows, window_type)
 
     if da.chunks:


### PR DESCRIPTION
When window weighting is applied with the power_spectrum functions, the input `dim` is passed directly to `_apply_window` to determine the correction weights. But `_apply_window` expects `dims` to be a list. This PR copies the same logic applied in `dft` and `idft` into `_apply_window` to force `dims` to be a list.

Closes #142 