### PR TITLE
A deprecation cycle to unify fft and dft by dropping the latter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,22 +4,22 @@ xrft: Fourier transforms for xarray data
 |pypi| |conda forge| |conda-forge| |Build Status| |codecov| |docs| |DOI| |license| |Code style|
 
 **xrft** is an open-source Python package for
-taking the discrete Fourier transform (DFT) on xarray_ and dask_ arrays.
+taking the Fast Fourier transform (FFT) on xarray_ and dask_ arrays.
 
 .. _xarray: http://xarray.pydata.org/en/stable/
 .. _dask: https://dask.org
 
 It is:
 
-- **Powerful**: It keeps the metadata and coordinates of the original xarray dataset and provides a clean work flow of DFT.
+- **Powerful**: It keeps the metadata and coordinates of the original xarray dataset and provides a clean work flow of FFT.
 - **Easy-to-use**: It uses the native arguments of `numpy FFT`_ and provides a simple, high-level API.
-- **Fast**: It uses the `dask API of FFT`_ and `map_blocks`_ to allow parallelization of DFT.
+- **Fast**: It uses the `dask API of FFT`_ and `map_blocks`_ to allow parallelization of FFT.
 
 .. _numpy FFT: https://docs.scipy.org/doc/numpy/reference/routines.fft.html
 .. _dask API of FFT: http://docs.dask.org/en/latest/array-api.html?highlight=fft#fast-fourier-transforms
 .. _map_blocks: http://docs.dask.org/en/latest/array-api.html?highlight=map_blocks#dask.array.core.map_blocks
 
-Please cite the `doi <https://doi.org/10.5281/zenodo.1402635>`_ if you find this
+Please cite the `DOI <https://doi.org/10.5281/zenodo.1402635>`_ if you find this
 package useful in order to support its continuous development.
 
 Get in touch

--- a/xrft/tests/test_detrend.py
+++ b/xrft/tests/test_detrend.py
@@ -27,7 +27,7 @@ def noise(dims, shape):
 @pytest.mark.parametrize("dim", ["t", "time"])
 @pytest.mark.parametrize("detrend_type", ["constant", "linear"])
 def test_dim_format(dim, detrend_type):
-    """ Check that detrend can deal with dim in various formats"""
+    """Check that detrend can deal with dim in various formats"""
     data = xr.DataArray(
         np.random.random([10]),
         dims=[dim],

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -786,7 +786,7 @@ def test_parseval(chunks_to_segments):
             )
         },
     )
-    FTs = xrft.dft(s, dim="x", true_phase=True, true_amplitude=True)
+    FTs = xrft.fft(s, dim="x", true_phase=True, true_amplitude=True)
     npt.assert_almost_equal(
         (np.abs(s) ** 2).sum() * dx, (np.abs(FTs) ** 2).sum() * FTs["freq_x"].spacing
     )
@@ -810,7 +810,7 @@ def test_parseval(chunks_to_segments):
             ),
         },
     )
-    FTs = xrft.dft(s, dim=("x", "y"), true_phase=True, true_amplitude=True)
+    FTs = xrft.fft(s, dim=("x", "y"), true_phase=True, true_amplitude=True)
     npt.assert_almost_equal(
         (np.abs(s) ** 2).sum() * dx * dy,
         (np.abs(FTs) ** 2).sum() * FTs["freq_x"].spacing * FTs["freq_y"].spacing,
@@ -1135,7 +1135,7 @@ def test_true_phase_preservation(chunk):
     if chunk:
         s1 = s1.chunk()
 
-    S1 = xrft.dft(s1, dim="x", true_phase=True)
+    S1 = xrft.fft(s1, dim="x", true_phase=True)
     assert s1.chunks == S1.chunks
 
     N3 = N1
@@ -1153,7 +1153,7 @@ def test_true_phase_preservation(chunk):
     if chunk:
         s2 = s2.chunk()
 
-    S2 = xrft.dft(s2, dim="x", true_phase=True)
+    S2 = xrft.fft(s2, dim="x", true_phase=True)
     assert s2.chunks == S2.chunks
 
     xrt.assert_allclose(S1, S2)
@@ -1172,7 +1172,7 @@ def test_true_phase():
     f = np.fft.fftfreq(len(x), dx)
     expected = np.fft.fft(np.fft.ifftshift(y)) * np.exp(-1j * 2.0 * np.pi * f * lag)
     expected = xr.DataArray(expected, dims="freq_x", coords={"freq_x": f})
-    output = xrft.dft(
+    output = xrft.fft(
         s, dim="x", true_phase=True, true_amplitude=False, shift=False, prefix="freq_"
     )
     xrt.assert_allclose(expected, output)
@@ -1187,7 +1187,7 @@ def test_theoretical_matching(rtol=1e-8, atol=1e-3):
     y = np.cos(2.0 * np.pi * f0 * x)
     y[np.abs(x) >= (T / 2.0)] = 0.0
     s = xr.DataArray(y, dims=("x",), coords={"x": x})
-    S = xrft.dft(
+    S = xrft.fft(
         s, dim="x", true_phase=True, true_amplitude=True
     )  # Fast Fourier Transform of original signal
     f = S.freq_x  # Frequency axis
@@ -1214,8 +1214,8 @@ def test_real_dft_true_phase():
             )
         },
     )
-    s1 = xrft.dft(s, dim="x", true_phase=True, shift=True)
-    s2 = xrft.dft(s, real_dim="x", true_phase=True, shift=True)
+    s1 = xrft.fft(s, dim="x", true_phase=True, shift=True)
+    s2 = xrft.fft(s, real_dim="x", true_phase=True, shift=True)
     s1 = np.conj(s1[{"freq_x": slice(None, s1.sizes["freq_x"] // 2 + 1)}])
     s1 = s1.assign_coords(freq_x=-s1["freq_x"]).sortby("freq_x")
     xrt.assert_allclose(s1, s2)
@@ -1250,11 +1250,11 @@ def test_idft_dft():
             * (np.arange(-N // 2, -N // 2 + N) + np.random.randint(-N // 2, N // 2))
         },
     )
-    FTs = xrft.dft(s, true_phase=True, true_amplitude=True)
+    FTs = xrft.fft(s, true_phase=True, true_amplitude=True)
     mean_lag = float(
         s["x"][{"x": s.sizes["x"] // 2}]
     )  # lag ensure IFTs to be on the same coordinate range than s
-    IFTs = xrft.idft(
+    IFTs = xrft.ifft(
         FTs, shift=True, true_phase=True, true_amplitude=True, lag=mean_lag
     )
     xrt.assert_allclose(s, IFTs)
@@ -1297,5 +1297,5 @@ def test_reversed_coordinates():
     )
     s2 = s.sortby("x")
     xrt.assert_allclose(
-        xrft.dft(s, dim="x", true_phase=True), xrft.dft(s2, dim="x", true_phase=True)
+        xrft.fft(s, dim="x", true_phase=True), xrft.fft(s2, dim="x", true_phase=True)
     )

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -356,7 +356,7 @@ class TestSpectrum(object):
     @pytest.mark.parametrize("window_correction", [True, False])
     @pytest.mark.parametrize("detrend", ["constant", "linear"])
     def test_dim_format(self, dim, window_correction, detrend):
-        """ Check that can deal with dim in various formats"""
+        """Check that can deal with dim in various formats"""
         data = xr.DataArray(
             np.random.random([10]),
             dims=[dim],

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -236,6 +236,7 @@ def _lag_coord(coord):
     else:
         return lag.data
 
+
 def dft(da, dim=None, **kwargs):  # pragma: no cover
     """
     Deprecated function. See fft doc
@@ -247,6 +248,7 @@ def dft(da, dim=None, **kwargs):  # pragma: no cover
     warnings.warn(msg, Warning)
     return fft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
+
 def idft(daft, dim=None, **kwargs):  # pragma: no cover
     """
     Deprecated function. See ifft doc
@@ -257,45 +259,6 @@ def idft(daft, dim=None, **kwargs):  # pragma: no cover
     )
     warnings.warn(msg, Warning)
     return ifft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
-
-# def fft(da, dim=None, **kwargs):
-#     """
-#     da : `xarray.DataArray`
-#         The data to be transformed
-#     dim : str or sequence of str, optional
-#         The dimensions along which to take the transformation. If `None`, all
-#         dimensions will be transformed. If the inputs are dask arrays, the
-#         arrays must not be chunked along these dimensions.
-#     kwargs: See xrft.dft for argument list
-#     """
-#     if kwargs.pop("true_phase", False):
-#         warnings.warn("true_phase argument is ignored in xrft.fft")
-#     if kwargs.pop("true_amplitude", False):
-#         warnings.warn("true_amplitude argument is ignored in xrft.fft")
-#     with warnings.catch_warnings():
-#         warnings.simplefilter("ignore")
-#         return dft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
-#
-#
-# def ifft(daft, dim=None, **kwargs):
-#     """
-#     daft : `xarray.DataArray`
-#         The data to be transformed
-#     dim : str or sequence of str, optional
-#         The dimensions along which to take the transformation. If `None`, all
-#         dimensions will be transformed. If the inputs are dask arrays, the
-#         arrays must not be chunked along these dimensions.
-#     kwargs: See xrft.idft for argument list
-#     """
-#     if kwargs.pop("true_phase", False):
-#         warnings.warn("true_phase argument is ignored in xrft.ifft")
-#     if kwargs.pop("true_amplitude", False):
-#         warnings.warn("true_amplitude argument is ignored in xrft.ifft")
-#     if kwargs.pop("lag", False):
-#         warnings.warn("lag argument is ignored in xrft.ifft")
-#     with warnings.catch_warnings():
-#         warnings.simplefilter("ignore")
-#         return idft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
 
 def fft(

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -237,7 +237,9 @@ def _lag_coord(coord):
         return lag.data
 
 
-def dft(da, dim=None, **kwargs):  # pragma: no cover
+def dft(
+    da, dim=None, true_phase=False, true_amplitude=False, **kwargs
+):  # pragma: no cover
     """
     Deprecated function. See fft doc
     """
@@ -246,10 +248,14 @@ def dft(da, dim=None, **kwargs):  # pragma: no cover
         + " Please use `fft` instead"
     )
     warnings.warn(msg, FutureWarning)
-    return fft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+    return fft(
+        da, dim=dim, true_phase=true_phase, true_amplitude=true_amplitude, **kwargs
+    )
 
 
-def idft(daft, dim=None, **kwargs):  # pragma: no cover
+def idft(
+    daft, dim=None, true_phase=False, true_amplitude=False, **kwargs
+):  # pragma: no cover
     """
     Deprecated function. See ifft doc
     """
@@ -258,7 +264,9 @@ def idft(daft, dim=None, **kwargs):  # pragma: no cover
         + " Please use `ifft` instead"
     )
     warnings.warn(msg, FutureWarning)
-    return ifft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+    return ifft(
+        daft, dim=dim, true_phase=true_phase, true_amplitude=true_amplitude, **kwargs
+    )
 
 
 def fft(

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -280,7 +280,7 @@ def fft(
     specified dimensions.
 
     .. math::
-        daft = \mathbb{F}(da - \overline{da})
+        daft = \mathbb{F}(da)
 
     Parameters
     ----------
@@ -461,7 +461,7 @@ def ifft(
     specified dimensions.
 
     .. math::
-        da = \mathbb{F}(daft - \overline{daft})
+        da = \mathbb{F}(daft)
 
     Parameters
     ----------

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -236,48 +236,69 @@ def _lag_coord(coord):
     else:
         return lag.data
 
-
-def fft(da, dim=None, **kwargs):
+def dft(da, dim=None, **kwargs):  # pragma: no cover
     """
-    da : `xarray.DataArray`
-        The data to be transformed
-    dim : str or sequence of str, optional
-        The dimensions along which to take the transformation. If `None`, all
-        dimensions will be transformed. If the inputs are dask arrays, the
-        arrays must not be chunked along these dimensions.
-    kwargs: See xrft.dft for argument list
+    Deprecated function. See fft doc
     """
-    if kwargs.pop("true_phase", False):
-        warnings.warn("true_phase argument is ignored in xrft.fft")
-    if kwargs.pop("true_amplitude", False):
-        warnings.warn("true_amplitude argument is ignored in xrft.fft")
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return dft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+    msg = (
+        "This function has been renamed and will disappear in the future."
+        + " Please use `fft` instead"
+    )
+    warnings.warn(msg, Warning)
+    return fft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
-
-def ifft(daft, dim=None, **kwargs):
+def idft(daft, dim=None, **kwargs):  # pragma: no cover
     """
-    daft : `xarray.DataArray`
-        The data to be transformed
-    dim : str or sequence of str, optional
-        The dimensions along which to take the transformation. If `None`, all
-        dimensions will be transformed. If the inputs are dask arrays, the
-        arrays must not be chunked along these dimensions.
-    kwargs: See xrft.idft for argument list
+    Deprecated function. See ifft doc
     """
-    if kwargs.pop("true_phase", False):
-        warnings.warn("true_phase argument is ignored in xrft.ifft")
-    if kwargs.pop("true_amplitude", False):
-        warnings.warn("true_amplitude argument is ignored in xrft.ifft")
-    if kwargs.pop("lag", False):
-        warnings.warn("lag argument is ignored in xrft.ifft")
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return idft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+    msg = (
+        "This function has been renamed and will disappear in the future."
+        + " Please use `ifft` instead"
+    )
+    warnings.warn(msg, Warning)
+    return ifft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+
+# def fft(da, dim=None, **kwargs):
+#     """
+#     da : `xarray.DataArray`
+#         The data to be transformed
+#     dim : str or sequence of str, optional
+#         The dimensions along which to take the transformation. If `None`, all
+#         dimensions will be transformed. If the inputs are dask arrays, the
+#         arrays must not be chunked along these dimensions.
+#     kwargs: See xrft.dft for argument list
+#     """
+#     if kwargs.pop("true_phase", False):
+#         warnings.warn("true_phase argument is ignored in xrft.fft")
+#     if kwargs.pop("true_amplitude", False):
+#         warnings.warn("true_amplitude argument is ignored in xrft.fft")
+#     with warnings.catch_warnings():
+#         warnings.simplefilter("ignore")
+#         return dft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
+#
+#
+# def ifft(daft, dim=None, **kwargs):
+#     """
+#     daft : `xarray.DataArray`
+#         The data to be transformed
+#     dim : str or sequence of str, optional
+#         The dimensions along which to take the transformation. If `None`, all
+#         dimensions will be transformed. If the inputs are dask arrays, the
+#         arrays must not be chunked along these dimensions.
+#     kwargs: See xrft.idft for argument list
+#     """
+#     if kwargs.pop("true_phase", False):
+#         warnings.warn("true_phase argument is ignored in xrft.ifft")
+#     if kwargs.pop("true_amplitude", False):
+#         warnings.warn("true_amplitude argument is ignored in xrft.ifft")
+#     if kwargs.pop("lag", False):
+#         warnings.warn("lag argument is ignored in xrft.ifft")
+#     with warnings.catch_warnings():
+#         warnings.simplefilter("ignore")
+#         return idft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
 
-def dft(
+def fft(
     da,
     spacing_tol=1e-3,
     dim=None,
@@ -342,7 +363,7 @@ def dft(
     """
 
     if not true_phase and not true_amplitude:
-        msg = "Flags true_phase and true_amplitude will be set to True in future versions of xrft.dft to preserve the theoretical phasing and amplitude of Fourier Transform. Consider using xrft.fft to ensure future compatibility with numpy.fft like behavior and to deactivate this warning."
+        msg = "Flags true_phase and true_amplitude will be set to True in future versions of xrft.fft to preserve the theoretical phasing and amplitude of Fourier Transform. Consider using xrft.fft to ensure future compatibility with numpy.fft like behavior and to deactivate this warning."
         warnings.warn(msg, FutureWarning)
 
     if dim is None:
@@ -353,7 +374,7 @@ def dft(
 
     if "real" in kwargs:
         real_dim = kwargs.get("real")
-        msg = "`real` flag will be deprecated in future version of xrft.dft and replaced by `real_dim` flag."
+        msg = "`real` flag will be deprecated in future version of xrft.fft and replaced by `real_dim` flag."
         warnings.warn(msg, FutureWarning)
 
     if real_dim is not None:
@@ -459,7 +480,7 @@ def dft(
     )  # Do nothing if da was not transposed
 
 
-def idft(
+def ifft(
     daft,
     spacing_tol=1e-3,
     dim=None,
@@ -517,7 +538,7 @@ def idft(
     """
 
     if not true_phase and not true_amplitude:
-        msg = "Flags true_phase and true_amplitude will be set to True in future versions of xrft.idft to preserve the theoretical phasing and amplitude of Inverse Fourier Transform. Consider using xrft.ifft to ensure future compatibility with numpy.ifft like behavior and to deactivate this warning."
+        msg = "Flags true_phase and true_amplitude will be set to True in future versions of xrft.ifft to preserve the theoretical phasing and amplitude of Inverse Fourier Transform. Consider using xrft.ifft to ensure future compatibility with numpy.ifft like behavior and to deactivate this warning."
         warnings.warn(msg, FutureWarning)
 
     if dim is None:
@@ -528,7 +549,7 @@ def idft(
 
     if "real" in kwargs:
         real_dim = kwargs.get("real")
-        msg = "`real` flag will be deprecated in future version of xrft.idft and replaced by `real_dim` flag."
+        msg = "`real` flag will be deprecated in future version of xrft.ifft and replaced by `real_dim` flag."
         warnings.warn(msg, FutureWarning)
     if real_dim is not None:
         if real_dim not in daft.dims:
@@ -546,7 +567,7 @@ def idft(
         if len(dim) != len(lag):
             raise ValueError("dim and lag must have the same length.")
         if not true_phase:
-            msg = "Setting lag with true_phase=False does not guarantee accurate idft."
+            msg = "Setting lag with true_phase=False does not guarantee accurate ifft."
             warnings.warn(msg, Warning)
 
         for d, l in zip(dim, lag):
@@ -680,7 +701,7 @@ def power_spectrum(
         If scaling = 'density', correct for the energy (integral) of the spectrum. This ensures, for example, that the power spectral density integrates to the square of the RMS of the signal (ie that Parseval's theorem is satisfied). Note that in most cases, Parseval's theorem will only be approximately satisfied with this correction as it assumes that the signal being windowed is independent of the window. The correction becomes more accurate as the width of the window gets large in comparison with any noticeable period in the signal.
         If False, the spectrum gives a representation of the power in the windowed signal.
         Note that when True, Parseval's theorem may only be approximately satisfied.
-    kwargs : dict : see xrft.dft for argument list
+    kwargs : dict : see xrft.fft for argument list
     """
 
     if "density" in kwargs:
@@ -702,7 +723,7 @@ def power_spectrum(
         {"true_amplitude": True, "true_phase": False}
     )  # true_phase do not matter in power_spectrum
 
-    daft = dft(da, dim=dim, real_dim=real_dim, **kwargs)
+    daft = fft(da, dim=dim, real_dim=real_dim, **kwargs)
     updated_dims = [
         d for d in daft.dims if (d not in da.dims and "segment" not in d)
     ]  # Transformed dimensions
@@ -786,12 +807,12 @@ def cross_spectrum(
         If scaling = 'density', correct for the energy (integral) of the spectrum. This ensures, for example, that the power spectral density integrates to the square of the RMS of the signal (ie that Parseval's theorem is satisfied). Note that in most cases, Parseval's theorem will only be approximately satisfied with this correction as it assumes that the signal being windowed is independent of the window. The correction becomes more accurate as the width of the window gets large in comparison with any noticeable period in the signal.
         If False, the spectrum gives a representation of the power in the windowed signal.
         Note that when True, Parseval's theorem may only be approximately satisfied.
-    kwargs : dict : see xrft.dft for argument list
+    kwargs : dict : see xrft.fft for argument list
     """
 
     if "true_phase" not in kwargs:
         msg = (
-            "true_phase flag will be set to True in future version of xrft.dft possibly impacting cross_spectrum output. "
+            "true_phase flag will be set to True in future version of xrft.fft possibly impacting cross_spectrum output. "
             + "Set explicitely true_phase = False in cross_spectrum arguments list to ensure future compatibility "
             + "with numpy-like behavior where the coordinates are disregarded."
         )
@@ -815,8 +836,8 @@ def cross_spectrum(
 
     kwargs.update({"true_amplitude": True})
 
-    daft1 = dft(da1, dim=dim, real_dim=real_dim, **kwargs)
-    daft2 = dft(da2, dim=dim, real_dim=real_dim, **kwargs)
+    daft1 = fft(da1, dim=dim, real_dim=real_dim, **kwargs)
+    daft2 = fft(da2, dim=dim, real_dim=real_dim, **kwargs)
 
     if daft1.dims != daft2.dims:
         raise ValueError("The two datasets have different dimensions")
@@ -883,11 +904,11 @@ def cross_phase(da1, da2, dim=None, **kwargs):
         The data to be transformed
     da2 : `xarray.DataArray`
         The data to be transformed
-    kwargs : dict : see xrft.dft for argument list
+    kwargs : dict : see xrft.fft for argument list
     """
     if "true_phase" not in kwargs:
         msg = (
-            "true_phase flag will be set to True in future version of xrft.dft possibly impacting cross_phase output. "
+            "true_phase flag will be set to True in future version of xrft.fft possibly impacting cross_phase output. "
             + "Set explicitely true_phase = False in cross_spectrum arguments list to ensure future compatibility "
             + "with numpy-like behavior where the coordinates are disregarded."
         )

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -245,7 +245,7 @@ def dft(da, dim=None, **kwargs):  # pragma: no cover
         "This function has been renamed and will disappear in the future."
         + " Please use `fft` instead"
     )
-    warnings.warn(msg, Warning)
+    warnings.warn(msg, FutureWarning)
     return fft(da, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
 
@@ -257,7 +257,7 @@ def idft(daft, dim=None, **kwargs):  # pragma: no cover
         "This function has been renamed and will disappear in the future."
         + " Please use `ifft` instead"
     )
-    warnings.warn(msg, Warning)
+    warnings.warn(msg, FutureWarning)
     return ifft(daft, dim=dim, true_phase=False, true_amplitude=False, **kwargs)
 
 
@@ -1001,7 +1001,7 @@ def isotropic_powerspectrum(*args, **kwargs):  # pragma: no cover
         "This function has been renamed and will disappear in the future."
         + " Please use isotropic_power_spectrum instead"
     )
-    warnings.warn(msg, Warning)
+    warnings.warn(msg, FutureWarning)
     return isotropic_power_spectrum(*args, **kwargs)
 
 
@@ -1093,7 +1093,7 @@ def isotropic_crossspectrum(*args, **kwargs):  # pragma: no cover
         "This function has been renamed and will disappear in the future."
         + " Please use isotropic_cross_spectrum instead"
     )
-    warnings.warn(msg, Warning)
+    warnings.warn(msg, FutureWarning)
     return isotropic_cross_spectrum(*args, **kwargs)
 
 


### PR DESCRIPTION
A PR to avoid the confusion between `fft` and `dft` by adding a deprecation warning to when `dft` is called.