### PR TITLE
Update `axis_num` when `detrend='linear'` is taken

### DIFF
--- a/xrft/detrend.py
+++ b/xrft/detrend.py
@@ -9,7 +9,8 @@ import scipy.linalg as spl
 
 
 def detrend(da, dim, detrend_type="constant"):
-    """Detrend a DataArray
+    """
+    Detrend a DataArray
 
     Parameters
     ----------

--- a/xrft/tests/test_detrend.py
+++ b/xrft/tests/test_detrend.py
@@ -27,7 +27,7 @@ def noise(dims, shape):
 @pytest.mark.parametrize("dim", ["t", "time"])
 @pytest.mark.parametrize("detrend_type", ["constant", "linear"])
 def test_dim_format(dim, detrend_type):
-    """ Check that detrend can deal with dim in various formats"""
+    """Check that detrend can deal with dim in various formats"""
     data = xr.DataArray(
         np.random.random([10]),
         dims=[dim],

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -356,7 +356,7 @@ class TestSpectrum(object):
     @pytest.mark.parametrize("window_correction", [True, False])
     @pytest.mark.parametrize("detrend", ["constant", "linear"])
     def test_dim_format(self, dim, window_correction, detrend):
-        """ Check that can deal with dim in various formats"""
+        """Check that can deal with dim in various formats"""
         data = xr.DataArray(
             np.random.random([10]),
             dims=[dim],

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -411,8 +411,10 @@ def dft(
         delta_x.append(delta)
         lag_x.append(lag)
 
-    if detrend:
+    if detrend is not None:
         da = _detrend(da, dim, detrend_type=detrend)
+        # Update the axis_num upon detrending
+        axis_num = [da.get_axis_num(d) for d in dim]
 
     if window is not None:
         _, da = _apply_window(da, dim, window_type=window)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -413,7 +413,8 @@ def dft(
 
     if detrend is not None:
         if detrend == "linear":
-            da = _detrend(da, dim, detrend_type=detrend).transpose(*rawdims)
+            orig_dims = da.dims
+            da = _detrend(da, dim, detrend_type=detrend).transpose(*orig_dims)
         else:
             da = _detrend(da, dim, detrend_type=detrend)
 
@@ -558,12 +559,12 @@ def idft(
     if chunks_to_segments:
         daft = _stack_chunks(daft, dim)
 
+    rawdims = daft.dims  # take care of segmented dimensions, if any
+
     if real_dim is not None:
         daft = daft.transpose(
             *[d for d in daft.dims if d not in [real_dim]] + [real_dim]
         )  # dimension for real transformed is moved at the end
-
-    rawdims = daft.dims  # take care of segmented dimensions, if any
 
     fftm = _fft_module(daft)
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -412,7 +412,7 @@ def dft(
         lag_x.append(lag)
 
     if detrend is not None:
-        if detrend == 'linear':
+        if detrend == "linear":
             da = _detrend(da, dim, detrend_type=detrend).transpose(*rawdims)
         else:
             da = _detrend(da, dim, detrend_type=detrend)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -412,9 +412,10 @@ def dft(
         lag_x.append(lag)
 
     if detrend is not None:
-        da = _detrend(da, dim, detrend_type=detrend)
-        # Update the axis_num upon detrending
-        axis_num = [da.get_axis_num(d) for d in dim]
+        if detrend == 'linear':
+            da = _detrend(da, dim, detrend_type=detrend).transpose(*rawdims)
+        else:
+            da = _detrend(da, dim, detrend_type=detrend)
 
     if window is not None:
         _, da = _apply_window(da, dim, window_type=window)
@@ -557,12 +558,12 @@ def idft(
     if chunks_to_segments:
         daft = _stack_chunks(daft, dim)
 
-    rawdims = daft.dims  # take care of segmented dimesions, if any
-
     if real_dim is not None:
         daft = daft.transpose(
             *[d for d in daft.dims if d not in [real_dim]] + [real_dim]
         )  # dimension for real transformed is moved at the end
+
+    rawdims = daft.dims  # take care of segmented dimensions, if any
 
     fftm = _fft_module(daft)
 


### PR DESCRIPTION
This addresses issue #159 and updates the `axis_num` when `detrend='linear'` because the latter changes the order of the dimensions.