### PR TITLE
Raise error for non-dimensional coordinates

### DIFF
--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -351,8 +351,6 @@ def test_window_single_dim():
     ps.load()
 
 
-
-
 class TestSpectrum(object):
     @pytest.mark.parametrize("dim", ["t", "time"])
     @pytest.mark.parametrize("window_correction", [True, False])
@@ -1309,6 +1307,7 @@ def test_reversed_coordinates():
         xrft.dft(s, dim="x", true_phase=True), xrft.dft(s2, dim="x", true_phase=True)
     )
 
+
 def test_nondim_coords():
     """Error should be raised if there are non-dimensional coordinates attached to the dimension(s) over which the FFT is being taken"""
     N = 16
@@ -1319,12 +1318,11 @@ def test_nondim_coords():
             "time": np.array(["2019-04-18", "2019-04-19"], dtype="datetime64"),
             "x": range(N),
             "y": range(N),
-            "x_nondim":("x",np.arange(N))
+            "x_nondim": ("x", np.arange(N)),
         },
     )
-    
+
     with pytest.raises(ValueError):
         xrft.power_spectrum(da)
-    
-    xrft.power_spectrum(da,dim=["time","y"])
 
+    xrft.power_spectrum(da, dim=["time", "y"])

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -1319,12 +1319,12 @@ def test_nondim_coords():
             "time": np.array(["2019-04-18", "2019-04-19"], dtype="datetime64"),
             "x": range(N),
             "y": range(N),
-            'x_nondim':('x',np.arange(N))
+            "x_nondim":("x",np.arange(N))
         },
     )
     
     with pytest.raises(ValueError):
         xrft.power_spectrum(da)
     
-    xrft.power_spectrum(da,dim=['time','y'])
+    xrft.power_spectrum(da,dim=["time","y"])
 

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -351,6 +351,8 @@ def test_window_single_dim():
     ps.load()
 
 
+
+
 class TestSpectrum(object):
     @pytest.mark.parametrize("dim", ["t", "time"])
     @pytest.mark.parametrize("window_correction", [True, False])
@@ -1306,3 +1308,23 @@ def test_reversed_coordinates():
     xrt.assert_allclose(
         xrft.dft(s, dim="x", true_phase=True), xrft.dft(s2, dim="x", true_phase=True)
     )
+
+def test_nondim_coords():
+    """Error should be raised if there are non-dimensional coordinates attached to the dimension(s) over which the FFT is being taken"""
+    N = 16
+    da = xr.DataArray(
+        np.random.rand(2, N, N),
+        dims=["time", "x", "y"],
+        coords={
+            "time": np.array(["2019-04-18", "2019-04-19"], dtype="datetime64"),
+            "x": range(N),
+            "y": range(N),
+            'x_nondim':('x',np.arange(N))
+        },
+    )
+    
+    with pytest.raises(ValueError):
+        xrft.power_spectrum(da)
+    
+    xrft.power_spectrum(da,dim=['time','y'])
+

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -383,6 +383,13 @@ def fft(
 
     N = [da.shape[n] for n in axis_num]
 
+    # raise error if there are multiple coordinates attached to the dimension(s) over which the FFT is taken
+    for d in dim:
+        if not da[d].equals(da[d].reset_coords(drop=True)):
+            raise ValueError(
+                "This function currently does not handle more than one coordinate attached to the dimension(s) over which the FFT is taken."
+                )
+
     # verify even spacing of input coordinates
     delta_x = []
     lag_x = []

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -385,7 +385,8 @@ def fft(
 
     # raise error if there are multiple coordinates attached to the dimension(s) over which the FFT is taken
     for d in dim:
-        if not da[d].equals(da[d].reset_coords(drop=True)):
+        bad_coords = [cname for cname in da.coords if cname != dim and dim in da[cname].dims]
+        if bad_coords:
             raise ValueError(
                 "This function currently does not handle more than one coordinate attached to the dimension(s) over which the FFT is taken."
             )

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -388,7 +388,8 @@ def fft(
         bad_coords = [cname for cname in da.coords if cname != dim and dim in da[cname].dims]
         if bad_coords:
             raise ValueError(
-                "This function currently does not handle more than one coordinate attached to the dimension(s) over which the FFT is taken."
+                f"The input array contains coordinate variable(s) ({bad_coords}) whose dims include the transform dimension(s) `{dim}`. "
+                f"Please drop these coordinates (`.drop({bad_coords}`) before invoking xrft."
             )
 
     # verify even spacing of input coordinates

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -386,11 +386,11 @@ def fft(
     # raise error if there are multiple coordinates attached to the dimension(s) over which the FFT is taken
     for d in dim:
         bad_coords = [
-            cname for cname in da.coords if cname != dim and dim in da[cname].dims
+            cname for cname in da.coords if cname != d and d in da[cname].dims
         ]
         if bad_coords:
             raise ValueError(
-                f"The input array contains coordinate variable(s) ({bad_coords}) whose dims include the transform dimension(s) `{dim}`. "
+                f"The input array contains coordinate variable(s) ({bad_coords}) whose dims include the transform dimension(s) `{d}`. "
                 f"Please drop these coordinates (`.drop({bad_coords}`) before invoking xrft."
             )
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -388,7 +388,7 @@ def fft(
         if not da[d].equals(da[d].reset_coords(drop=True)):
             raise ValueError(
                 "This function currently does not handle more than one coordinate attached to the dimension(s) over which the FFT is taken."
-                )
+            )
 
     # verify even spacing of input coordinates
     delta_x = []

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -385,7 +385,9 @@ def fft(
 
     # raise error if there are multiple coordinates attached to the dimension(s) over which the FFT is taken
     for d in dim:
-        bad_coords = [cname for cname in da.coords if cname != dim and dim in da[cname].dims]
+        bad_coords = [
+            cname for cname in da.coords if cname != dim and dim in da[cname].dims
+        ]
         if bad_coords:
             raise ValueError(
                 f"The input array contains coordinate variable(s) ({bad_coords}) whose dims include the transform dimension(s) `{dim}`. "


### PR DESCRIPTION
This PR has two additions (see issue #162):

- raises an error in `xrft.fft()`  when there are multiple coordinates attached to the same dimensions (added in `xrft.py`)
- tests for the above error (added to `test_xrft.py`)

Note that I haven't contributed code for awhile, so a thorough read-through of what I've done would be great. Also, I have never used 'code-style' before, but I got a message stating that "all jobs have failed" and I'm not quite sure how to address this. So let me know if I need to update something here!