### PR TITLE
Fix `requires` in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Natural Language :: English
     Operating System :: OS Independent
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,26 +35,25 @@ install_requires =
     numpy
     pandas
     scipy
-    setuptools
 python_requires = >=3.6
-setup_requires = 
-    setuptools_scm
-    pytest-runner
-extra_requires = 
-    cftime
-    numpy_groupies
 
 [bdist_wheel]
 universal = 1
 
 [aliases]
-test=pytest
+test = pytest
 
 [options.extras_require]
+io =
+    cftime
+agg =
+    numpy_groupies
 test =
     pytest >= 6.2.2
     pytest-cov
 all =
+    %(io)s
+    %(agg)s
     %(test)s
 
 [flake8]
@@ -70,5 +70,5 @@ ignore =
     W503
 
 [isort]
-known_first_party=xrft
-known_third_party=dask,numpy,pandas,pytest,pytest_lazyfixture,setuptools,sphinx_book_theme,xarray,zarr
+known_first_party = xrft
+known_third_party = xarray,dask,numpy,pandas,scipy,cftime,numpy_groupies,pytest,setuptools


### PR DESCRIPTION
* removed `setuptools` from `install_requires`
* `setup_requires` info is specified in `pyproject.toml`, so removed it
* added initial groups for `cftime` and `numpy_groupies`