### PR TITLE
change _diff_coord to use nanosecond precision

### DIFF
--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -208,7 +208,9 @@ def _diff_coord(coord):
         coord = xr.DataArray(decoded_time, dims=coord.dims, coords=coord.coords)
         return np.diff(coord)
     elif pd.api.types.is_datetime64_dtype(v0):
-        return np.diff(coord).astype("timedelta64[s]").astype("f8")
+        diff = np.diff(coord).astype("timedelta64[ns]").astype("f8")
+        diff = (diff/1e9) #convert back to seconds
+        return diff
     else:
         return np.diff(coord)
 


### PR DESCRIPTION
this change allows for coordinates with precision below 1 second. The diff is then divided by 1e9 to maintain the apparent standard for time being expressed in seconds.

This is a potential quick fix for #203. 