### PR TITLE
Import `_version` without catching exception

### DIFF
--- a/xrft/__init__.py
+++ b/xrft/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from ._version import __version__
-except ImportError:
-    __version__ = "unknown"
+from ._version import __version__
 
 from .xrft import *  # noqa
 from .detrend import detrend


### PR DESCRIPTION
Allow `import xrft` to fail if the `xrft/_version.py` file doesn't exist. This way it will be possible to catch builds that didn't generate the `_version.py` file and could lead to versioning issues when releasing.

Related to #221
