### PR TITLE
Extend fft and ifft to allow cupy-xarray use

### DIFF
--- a/xrft/tests/test_padding.py
+++ b/xrft/tests/test_padding.py
@@ -59,7 +59,7 @@ def test_pad_coordinates_invalid(sample_da_2d):
     """
     Test if pad_coordinates raises error after unevenly spaced coords
     """
-    x = sample_da_2d.coords["x"].values
+    x = sample_da_2d.coords["x"].values.copy()
     x[3] += 0.1
     sample_da_2d = sample_da_2d.assign_coords({"x": x})
     with pytest.raises(ValueError):

--- a/xrft/tests/test_utils.py
+++ b/xrft/tests/test_utils.py
@@ -48,7 +48,7 @@ def test_get_spacing_unvenly_spaced(sample_da_2d):
     Check if error is raised after unvenly spaced coordinates
     """
     # Make the x coordinate unevenly spaced
-    x = sample_da_2d.x.values
+    x = sample_da_2d.x.values.copy()
     x[0] += 0.2
     da = sample_da_2d.assign_coords({"x": x})
     # Check if error is raised

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -1309,6 +1309,26 @@ def test_ifft_fft():
     npt.assert_allclose(s.data, IFTs.data)
 
 
+def test_ifft_fft_cp():
+    """
+    Testing ifft(fft(s.data)) == s.data
+    """
+    N = 20
+    s = xr.DataArray(
+        np.random.rand(N) + 1j * np.random.rand(N),
+        dims="x",
+        coords={"x": np.arange(0, N)},
+    ).cupy.as_cupy()
+    FTs = xrft.fft(s)
+    IFTs = xrft.ifft(FTs, shift=True)  # Shift=True is mandatory for the assestion below
+    npt.assert_allclose(s.as_numpy().data, IFTs.as_numpy().data)
+
+    # Check unshifted fft
+    FTs = xrft.fft(s, shift=False)
+    IFTs = xrft.ifft(FTs, shift=True)  # Shift=True is mandatory for the assestion below
+    npt.assert_allclose(s.as_numpy().data, IFTs.as_numpy().data)
+
+
 def test_idft_dft():
     """
     Testing idft(dft(s)) == s

--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -4,6 +4,9 @@ import xarray as xr
 import cftime
 import dask.array as dsar
 
+import cupy as cp
+import cupy_xarray
+
 import scipy.signal as sps
 
 import pytest
@@ -175,6 +178,31 @@ class TestFFTImag(object):
             npt.assert_almost_equal(daft.values, np.fft.fftn(da_prime, axes=[0]))
             npt.assert_array_equal(
                 daft.values, xrft.fft(da, dim="time", shift=False, detrend="linear")
+            )
+
+    @pytest.mark.parametrize("cupy", [False, True])
+    def test_fft_3d_cupy(self, cupy):
+        """Test the discrete Fourier transform on 3D cupy array data"""
+        N = 16
+        da = xr.DataArray(
+            np.random.rand(N, N, N),
+            dims=["time", "x", "y"],
+            coords={"time": range(N), "x": range(N), "y": range(N)},
+        )
+        if cupy:
+            da = da.cupy.as_cupy()
+            daft = xrft.fft(da, dim=["x", "y"], shift=False)
+            npt.assert_almost_equal(
+                daft.as_numpy().values, np.fft.fftn(da.as_numpy().values, axes=[1, 2])
+            )
+            daft = xrft.fft(da, dim=["time"], shift=False, detrend="linear")
+            da_prime = sps.detrend(da.as_numpy(), axis=0)
+            npt.assert_almost_equal(
+                daft.as_numpy().values, np.fft.fftn(da_prime, axes=[0])
+            )
+            npt.assert_array_equal(
+                daft.as_numpy().values,
+                xrft.fft(da, dim="time", shift=False, detrend="linear").as_numpy(),
             )
 
     @pytest.mark.skip(reason="3D detrending not implemented")

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -14,6 +14,9 @@ import scipy.signal as sps
 from .detrend import detrend as _detrend
 from pandas.api.types import is_numeric_dtype, is_datetime64_any_dtype
 
+import cupy as cp
+import cupy_xarray
+
 __all__ = [
     "fft",
     "ifft",
@@ -32,6 +35,8 @@ __all__ = [
 def _fft_module(da):
     if da.chunks:
         return dsar.fft
+    elif da.cupy.is_cupy:
+        return cp.fft
     else:
         return np.fft
 
@@ -436,10 +441,20 @@ def fft(
         reversed_axis = [
             da.get_axis_num(d) for d in dim if da[d][-1] < da[d][0]
         ]  # handling decreasing coordinates
-        f = fft_fn(
-            fftm.ifftshift(np.flip(da, axis=reversed_axis), axes=axis_num),
-            axes=axis_num,
-        )
+        if da.cupy.is_cupy:
+            f = fft_fn(
+                xr.apply_ufunc(
+                    fftm.ifftshift,
+                    np.flip(da, axis=reversed_axis),
+                    kwargs={"axes": axis_num},
+                ).data,
+                axes=axis_num,
+            )
+        else:
+            f = fft_fn(
+                fftm.ifftshift(np.flip(da, axis=reversed_axis), axes=axis_num),
+                axes=axis_num,
+            )
     else:
         f = fft_fn(da.data, axes=axis_num)
 
@@ -461,10 +476,15 @@ def fft(
 
     if true_phase:
         for up_dim, lag in zip(updated_dims, lag_x):
-            daft = daft * xr.DataArray(
+            mult = xr.DataArray(
                 np.exp(-1j * 2.0 * np.pi * newcoords[up_dim] * lag),
                 dims=up_dim,
                 coords={up_dim: newcoords[up_dim]},
+            )
+            if daft.cupy.is_cupy:
+                mult = mult.cupy.as_cupy()
+            daft = (
+                daft * mult
             )  # taking advantage of xarray broadcasting and ordered coordinates
             daft[up_dim].attrs.update({"direct_lag": lag})
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -593,7 +593,10 @@ def ifft(
 
     if true_phase:
         for d, l in zip(dim, lag):
-            daft = daft * np.exp(1j * 2.0 * np.pi * daft[d] * l)
+            mult = np.exp(1j * 2.0 * np.pi * daft[d] * l)
+            if daft.cupy.is_cupy:
+                mult = cp.array(mult)
+            daft = daft * mult
 
     if chunks_to_segments:
         daft = _stack_chunks(daft, dim)

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -438,23 +438,13 @@ def fft(
         _, da = _apply_window(da, dim, window_type=window)
 
     if true_phase:
-        reversed_axis = [
+        reversed_axis = tuple(
             da.get_axis_num(d) for d in dim if da[d][-1] < da[d][0]
-        ]  # handling decreasing coordinates
-        if da.cupy.is_cupy:
-            f = fft_fn(
-                xr.apply_ufunc(
-                    fftm.ifftshift,
-                    np.flip(da, axis=reversed_axis),
-                    kwargs={"axes": axis_num},
-                ).data,
-                axes=axis_num,
-            )
-        else:
-            f = fft_fn(
-                fftm.ifftshift(np.flip(da, axis=reversed_axis), axes=axis_num),
-                axes=axis_num,
-            )
+        )  # handling decreasing coordinates
+        f = fft_fn(
+            fftm.ifftshift(np.flip(da.data, axis=reversed_axis), axes=axis_num),
+            axes=axis_num,
+        )
     else:
         f = fft_fn(da.data, axes=axis_num)
 

--- a/xrft/xrft.py
+++ b/xrft/xrft.py
@@ -585,7 +585,7 @@ def ifft(
         for d, l in zip(dim, lag):
             mult = np.exp(1j * 2.0 * np.pi * daft[d] * l)
             if daft.cupy.is_cupy:
-                mult = cp.array(mult)
+                mult = mult.cupy.as_cupy()
             daft = daft * mult
 
     if chunks_to_segments:


### PR DESCRIPTION
Modifies the fft and ifft functions for compatibility with cupy-xarray, to allow for cuda-accelerated ffts. Resolves #77. I included at least some test coverage, but I don't know the test suite very well and I don't think I extended all tests. I also haven't tested cupy-dask combinations, which have caused problems for me elsewhere. Please let me know if this is a feature you're interested in, and if so whether it makes more sense to discuss it here or on the issue.